### PR TITLE
[Refactor] Run only prettier check on pre-commit hook - closes #71

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     }
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,md}": [
-      "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,md}\""
+    "src/**/*.{js,jsx,ts,tsx,json,md,scss,css}": [
+      "prettier --check"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,10 +61,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,md}": [
-      "eslint"
-    ],
-    "src/**/*.{js,jsx,ts,tsx,css,scss}": [
-      "stylelint"
+      "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,md}\""
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
The deleted parts were already included in the pre-push hook.

Contemplated adding a prettier check with a more detailed output, but eventually decided that there's no need since the most relevant information needed is if the changes require "prettier --write" to be ran.