### PR TITLE
Add accessibility statement for site

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -92,3 +92,10 @@ source_file = locale/af/typography.json
 source_lang = af
 type = KEYVALUEJSON
 
+[suomifi-design-system.accessibility-statement-json]
+file_filter = locale/<lang>/accessibility-statement.json
+minimum_perc = 0
+source_file = locale/af/accessibility-statement.json
+source_lang = af
+type = KEYVALUEJSON
+

--- a/locale/af/accessibility-statement.json
+++ b/locale/af/accessibility-statement.json
@@ -1,0 +1,85 @@
+{
+  "title": "title",
+  "intro": "intro",
+  "sections": [
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        },
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [{ "text": "section.link.text", "url": "section.link.url" }]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    }
+  ]
+}

--- a/locale/en/accessibility-statement.json
+++ b/locale/en/accessibility-statement.json
@@ -1,0 +1,85 @@
+{
+  "title": "title",
+  "intro": "intro",
+  "sections": [
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        },
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [{ "text": "section.link.text", "url": "section.link.url" }]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "text": "section.paragraph.text"
+        }
+      ]
+    }
+  ]
+}

--- a/locale/fi/accessibility-statement.json
+++ b/locale/fi/accessibility-statement.json
@@ -1,0 +1,85 @@
+{
+  "title": "Suomi.fi Design Systemin saavutettavuusseloste",
+  "intro": "",
+  "sections": [
+    {
+      "paragraphs": [
+        {
+          "text": "Tämä saavutettavuusseloste koskee Väestörekisterikeskuksen toteuttamaa Suomi.fi Design System -sivustoa. Seloste on laadittu 19.9.2019."
+        },
+        {
+          "text": "Suomi.fi Design System -sivuston saavutettavuutta on arvioinut Väestörekisterikeskuksen hankkima saavutettavuusasiantuntija säännöllisesti osana suunnittelu- ja kehitysprosessia."
+        }
+      ]
+    },
+    {
+      "title": "Digipalvelun saavutettavuuden tila",
+      "paragraphs": [
+        {
+          "text": "Verkkopalvelu täyttää suurelta osin saavutettavuusvaatimukset, eikä sivustolla ole kriittisiä saavutettavuuspuutteita (täyttää WCAG-ohjeistuksen A- ja AA-tason kriittiset vaatimukset). "
+        }
+      ]
+    },
+    {
+      "title": "Huomasitko saavutettavuuspuutteen sivustollamme? Kerro se meille ja teemme parhaamme puutteen korjaamiseksi",
+      "paragraphs": [
+        {
+          "text": "Ota yhteyttä sähköpostitse osoitteella: suomifi(at)suomi.fi"
+        }
+      ]
+    },
+    {
+      "title": "Valvontaviranomainen",
+      "paragraphs": [
+        {
+          "text": "Jos huomaat sivustolla saavutettavuusongelmia, anna ensin palautetta sivuston ylläpitäjälle. Vastauksessa voi mennä 14 päivää. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, voit antaa palautteen Etelä-Suomen aluehallintovirastoon. Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten valituksen voi tehdä ja miten asia käsitellään."
+        }
+      ]
+    },
+    {
+      "title": "Valvontaviranomaisen yhteystiedot",
+      "paragraphs": [
+        {
+          "text": "Etelä-Suomen aluehallintovirasto"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "Saavutettavuuden valvonnan yksikkö"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": ""
+        }
+      ],
+      "links": [{ "text": "www.saavutettavuusvaatimukset.fi", "url": "https://www.saavutettavuusvaatimukset.fi/" }]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "saavutettavuus(at)avi.fi"
+        }
+      ]
+    },
+    {
+      "paragraphs": [
+        {
+          "text": "puhelinnumero vaihde 0295 016 000"
+        }
+      ]
+    },
+    {
+      "title": "Teemme jatkuvasti työtä saavutettavuuden parantamiseksi",
+      "paragraphs": [
+        {
+          "text": "Saavutettavuus on huomioitu Väestörekisterikeskuksen digitaalisten palvelujen kehityksessä suunnittelusta toteutukseen kokonaisketterän mallin mukaisesti. Väestörekisterikeskuksen hankkima saavutettavuusasiantuntija arvioi palvelujen saavutettavuutta säännöllisesti osana suunnittelu- ja kehitystyötä."
+        }
+      ]
+    }
+  ]
+}

--- a/locale/fi/common.json
+++ b/locale/fi/common.json
@@ -13,8 +13,8 @@
   "footer.description": "Suomi.fi Design System -kirjaston kehityksestä vastaa Väestorekisterikeskus.",
   "footer.links": [
     { "text": "", "url": "" },
-    { "text": "Suomidigi.fi", "url": "https://suomidigi.fi/" },
-    { "text": "", "url": "" }
+    { "text": "Saavutettavuusseloste", "url": "/accessibility-statement" },
+    { "text": "Suomidigi.fi", "url": "https://suomidigi.fi/" }
   ],
   "footer.social.title": "Osallistu keskusteluun ja kehitystyöhön",
   "footer.social.description": "Onko sinulla kysymyksiä, ehdotuksia ideoita? Jaetaan parhaita käytäntöjä ja ratkaistaan haasteita yhdessä!",

--- a/src/pages/accessibility-statement.tsx
+++ b/src/pages/accessibility-statement.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import { NamespacesConsumer } from 'react-i18next';
+import { withI18next } from '@wapps/gatsby-plugin-i18next';
+import { suomifiTheme } from 'suomifi-ui-components';
+
+import Layout from 'components/layout';
+import SEO from 'components/seo';
+import Section from 'components/Section';
+import { Heading } from 'components/ResponsiveComponents';
+import Link from 'components/Link';
+
+const Page = (): JSX.Element => (
+  <NamespacesConsumer ns={['accessibility-statement']}>
+    {t => (
+      <Layout>
+        <div style={{ padding: `0 ${suomifiTheme.spacing.l}` }}>
+          <SEO title={t('title')} />
+          <Heading variant="h1">{t('title')}</Heading>
+          {t('sections').map((section, index) => (
+            <Section
+              key={index}
+              mainTitle={section.title}
+              paragraphs={section.paragraphs}
+              links={section.links}
+            />
+          ))}
+        </div>
+      </Layout>
+    )}
+  </NamespacesConsumer>
+);
+
+export default withI18next()(Page);
+
+export const query = graphql`
+  query($lng: String!) {
+    ...AllLocalesFragment
+  }
+`;

--- a/src/pages/accessibility-statement.tsx
+++ b/src/pages/accessibility-statement.tsx
@@ -8,7 +8,6 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import Section from 'components/Section';
 import { Heading } from 'components/ResponsiveComponents';
-import Link from 'components/Link';
 
 const Page = (): JSX.Element => (
   <NamespacesConsumer ns={['accessibility-statement']}>


### PR DESCRIPTION
This PR adds an accessibility statement for the site and a related link to the site footer.

- Accessibility statement is a new component
- Translations and content are stored in related localisation files

![Screenshot 2019-09-20 at 13 47 28](https://user-images.githubusercontent.com/53744258/65322285-146da300-dbaf-11e9-9988-98c7f92715ed.png)
