### PR TITLE
[Feature] Add link page

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -126,3 +126,10 @@ minimum_perc = 0
 source_file = locale/af/dropdown.json
 source_lang = af
 type = KEYVALUEJSON
+
+[suomifi-design-system.link-json]
+file_filter = locale/<lang>/link.json
+minimum_perc = 0
+source_file = locale/af/link.json
+source_lang = af
+type = KEYVALUEJSON

--- a/locale/af/link.json
+++ b/locale/af/link.json
@@ -1,0 +1,74 @@
+{
+    "title": "title",
+    "intro": "intro",
+    "note.title": "note.title",
+    "note.items": [
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item"
+    ],
+    "sections": [
+      {
+        "title": "section.title",
+        "paragraphs": [
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": "section.paragraph.text"
+          }
+        ],
+        "links": [
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          }
+        ]
+      },
+      {
+        "title": "section.title",
+        "paragraphs": [
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": "section.paragraph.text"
+          }
+        ],
+        "links": [
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          }
+        ]
+      },
+      {
+        "title": "section.title",
+        "paragraphs": [
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": "section.paragraph.text"
+          }
+        ],
+        "links": [
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          }
+        ]
+      }
+    ],
+    "exampleRegular.title": "exampleRegular.title",
+    "exampleRegular.description": "exampleRegular.description",
+    "exampleRegular.linkText": "exampleRegular.linkText",
+    "exampleExternal.title": "exampleExternal.title",
+    "exampleExternal.description": "exampleExternal.description",
+    "exampleExternal.linkText": "exampleExternal.linkText",
+    "exampleExternal.label": "exampleExternal.label"
+    
+  }
+  

--- a/locale/fi/link.json
+++ b/locale/fi/link.json
@@ -1,0 +1,79 @@
+{
+  "title": "Linkki (Link)",
+  "intro": "Linkkiä käytetään pääsääntöisesti navigaatioelementtinä",
+  "note.title": "Saavutettavuus ja käytettävyys",
+  "note.items": [
+    "Linkin tulee olla kuvaava ja sen tarkoitus ymmärrettävissä pelkästä linkin nimestä.",
+    "Linkin nimen on hyvä vastata kohdesivua, jonne linkki käyttäjän ohjaa.",
+    "Vältä geneerisiä, “Lue lisää”-tyyppisiä linkkejä, mutta jos linkin on välttämätöntä olla geneerinen, voidaan ruudunlukijaa varten lisätä Aria-teknologialla lisätieto kohdesivusta tyyliin: \"Lue lisää aiheesta Vanhemmuuden tuki\".",
+    "Linkkityylin tulee olla yhtenäinen. Suomifissa päädyttiin kuitenkin selkeyden vuoksi esittämään leipätekstin ulkopuoliset linkit ilman alleviivausta, koska jokaisen kohdan alleviivaus teki listoista vaikealukuisia. Poikkeuksena tähän luetaan myös navigaatiot, joissa ei käytetä linkkityylejä.",
+    "Yleensä heading-luokituksen mukainen otsikko ei ole linkki, vaan linkki esitetään erillisenä komponenttinaan. Poikkeuksena kuitenkin listaukset, jolloin linkin toistaminen jokaisen yksikön yhteydessä lisäisi listauksen pituutta.",
+    "Vältä saman linkin toistumista näkymässä samalla tai eri nimellä.",
+    "Jos linkki avaa tiedoston tai ohjaa käyttäjän pois sivustolta, pitää tiedon olla linkin yhteydessä sekä näkeville ja ruudunlukijakäyttäjille.",
+    "",
+    ""
+  ],
+  "sections": [
+    {
+      "title": "Mistä komponentti koostuu",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Linkkien väri on suomifi teemassa sininen (highlightBase). Jos linkki on estetty, käytetään harmaata (depthBase). Linkit on Suomifissa esitetty ilman alleviivausta, jolloin linkki on hover-tilassa alleviivattu. Leipätekstin joukossa linkkitekstit alleviivataan, jotta ne erottuvat muusta tekstistä. Alleviivatut linkit ovat hover-tilassa ilman alleviivausta."
+        },
+        {
+            "image.key": "",
+            "image.alt": "",
+            "text": "Vierailun jälkeisessä tilassa (visited state) linkin väri on violetti (accentTertiaryDark9). Tila indikoidaan kaikissa linkeissä lukuunottamatta päänavigaation linkkejä ja käänteisissä linkeissä. Huomioi, että jos muokkaat linkkien tilojen värejä, on hyvä valita värit, jotka erottuvat riittävästi toisistaan. Linkeissä ei ole välttämätöntä käyttää vierailun jälkeiselle tilalle eri väriä, mutta sen käytön on todettu parantavan huomattavasti tekstiä sisältävien näkymien luettavuutta. Lisäksi näin pystytään indikoimaan selkeämmin listanäkymissä käyttäjän jo vierailemat sivut."
+          }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
+    {
+      "title": "Koko ja käyttö",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Linkit eroavat painikkeista siinä, että ne eivät muokkaa tietoa tai käynnistä toimintoa. Linkit vievät käyttäjän uuteen paikkaan käyttöliittymässä siitä jossa käyttäjä parhaillaan on tai vievät käyttäjän kokonaan pois sivustolta (External Link)"
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
+    {
+      "title": "Komponentti käyttöliittymässä",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Suomi.fi -palveluissa käytetään eri käyttötarkoituksiin erilaisia variaatioita linkistä."
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    }
+  ],
+  "exampleRegular.title": "Linkki (Link)",
+  "exampleRegular.description": "Kirjasinkoko ja leikkaus on tasapainossa muun sisällön kanssa.",
+  "exampleRegular.linkText": "Esimerkkilinkki",
+  "exampleExternal.title": "Ulkoinen linkki (External link)",
+  "exampleExternal.description": "Linkeissä, jotka avautuvat uuteen ikkunaan on aina visuaalinen ja verbaalinen indikaatio",
+  "exampleExternal.linkText": "Ulkoinen linkki",
+  "exampleExternal.label": "Avautuu uuteen ikkunaan"
+}
+

--- a/locale/fi/link.json
+++ b/locale/fi/link.json
@@ -3,13 +3,13 @@
   "intro": "Linkkiä käytetään pääsääntöisesti navigaatioelementtinä",
   "note.title": "Saavutettavuus ja käytettävyys",
   "note.items": [
-    "Linkin tulee olla kuvaava ja sen tarkoitus ymmärrettävissä pelkästä linkin nimestä.",
-    "Linkin nimen on hyvä vastata kohdesivua, jonne linkki käyttäjän ohjaa.",
+    "Linkin tulee olla kuvaava ja sen tarkoituksen ymmärrettävissä pelkästä linkin nimestä.",
+    "Linkin nimen on hyvä vastata sen sivun otsikkoa, jonne linkki käyttäjän ohjaa.",
     "Vältä geneerisiä, “Lue lisää”-tyyppisiä linkkejä, mutta jos linkin on välttämätöntä olla geneerinen, voidaan ruudunlukijaa varten lisätä Aria-teknologialla lisätieto kohdesivusta tyyliin: \"Lue lisää aiheesta Vanhemmuuden tuki\".",
-    "Linkkityylin tulee olla yhtenäinen. Suomifissa päädyttiin kuitenkin selkeyden vuoksi esittämään leipätekstin ulkopuoliset linkit ilman alleviivausta, koska jokaisen kohdan alleviivaus teki listoista vaikealukuisia. Poikkeuksena tähän luetaan myös navigaatiot, joissa ei käytetä linkkityylejä.",
-    "Yleensä heading-luokituksen mukainen otsikko ei ole linkki, vaan linkki esitetään erillisenä komponenttinaan. Poikkeuksena kuitenkin listaukset, jolloin linkin toistaminen jokaisen yksikön yhteydessä lisäisi listauksen pituutta.",
+    "Linkkityylin tulee olla yhtenäinen. Suomi.fi design systemissä päädyttiin kuitenkin selkeyden vuoksi esittämään leipätekstin ulkopuoliset linkit ilman alleviivausta, koska jokaisen kohdan alleviivaus teki listoista vaikealukuisia. Poikkeuksena tähän luetaan myös navigaatiot, joissa ei käytetä linkkityylejä.",
+    "Yleensä heading-luokituksen mukainen otsikko ei ole linkki, vaan linkki esitetään erillisenä komponenttina. Poikkeuksena kuitenkin listaukset, jolloin linkin toistaminen jokaisen yksikön yhteydessä lisäisi listauksen pituutta.",
     "Vältä saman linkin toistumista näkymässä samalla tai eri nimellä.",
-    "Jos linkki avaa tiedoston tai ohjaa käyttäjän pois sivustolta, pitää tiedon olla linkin yhteydessä sekä näkeville ja ruudunlukijakäyttäjille.",
+    "Mikäli linkki avaa tiedoston tai ohjaa käyttäjän pois sivustolta, täytyy tämän tiedon olla linkin yhteydessä sekä näkeville ja ruudunlukijakäyttäjille.",
     "",
     ""
   ],
@@ -20,12 +20,12 @@
         {
           "image.key": "",
           "image.alt": "",
-          "text": "Linkkien väri on suomifi teemassa sininen (highlightBase). Jos linkki on estetty, käytetään harmaata (depthBase). Linkit on Suomifissa esitetty ilman alleviivausta, jolloin linkki on hover-tilassa alleviivattu. Leipätekstin joukossa linkkitekstit alleviivataan, jotta ne erottuvat muusta tekstistä. Alleviivatut linkit ovat hover-tilassa ilman alleviivausta."
+          "text": "Linkkien väri on Suomi.fi teemassa on sininen (highlightBase). Jos linkki on estetty, käytetään harmaata (depthBase). Linkit on Suomi.fi design systemissä esitetty ilman alleviivausta, jolloin linkki on hover-tilassa alleviivattu. Leipätekstin joukossa linkkitekstit alleviivataan, jotta ne erottuvat muusta tekstistä. Alleviivatut linkit ovat hover-tilassa ilman alleviivausta."
         },
         {
             "image.key": "",
             "image.alt": "",
-            "text": "Vierailun jälkeisessä tilassa (visited state) linkin väri on violetti (accentTertiaryDark9). Tila indikoidaan kaikissa linkeissä lukuunottamatta päänavigaation linkkejä ja käänteisissä linkeissä. Huomioi, että jos muokkaat linkkien tilojen värejä, on hyvä valita värit, jotka erottuvat riittävästi toisistaan. Linkeissä ei ole välttämätöntä käyttää vierailun jälkeiselle tilalle eri väriä, mutta sen käytön on todettu parantavan huomattavasti tekstiä sisältävien näkymien luettavuutta. Lisäksi näin pystytään indikoimaan selkeämmin listanäkymissä käyttäjän jo vierailemat sivut."
+            "text": "Vierailun jälkeisessä tilassa (visited state) linkin väri on violetti (accentTertiaryDark9). Tila indikoidaan kaikissa linkeissä lukuunottamatta päänavigaation linkkejä ja käänteisiä linkkejä. Huomioi, että jos muokkaat linkkien tilojen värejä, on hyvä valita värit, jotka erottuvat riittävästi toisistaan. Linkeissä ei ole välttämätöntä käyttää vierailun jälkeiselle tilalle eri väriä, mutta sen käytön on todettu parantavan huomattavasti tekstiä sisältävien näkymien luettavuutta. Lisäksi näin pystytään indikoimaan selkeämmin listanäkymissä käyttäjän jo vierailemat sivut."
           }
       ],
       "links": [
@@ -41,7 +41,7 @@
         {
           "image.key": "",
           "image.alt": "",
-          "text": "Linkit eroavat painikkeista siinä, että ne eivät muokkaa tietoa tai käynnistä toimintoa. Linkit vievät käyttäjän uuteen paikkaan käyttöliittymässä siitä jossa käyttäjä parhaillaan on tai vievät käyttäjän kokonaan pois sivustolta (External Link)"
+          "text": "Linkit eroavat painikkeista siinä, että ne eivät muokkaa tietoa tai käynnistä toimintoa. Linkit vievät käyttäjän uuteen paikkaan käyttöliittymässä tai kokonaan pois sivustolta (External Link)"
         }
       ],
       "links": [

--- a/locale/fi/link.json
+++ b/locale/fi/link.json
@@ -23,10 +23,10 @@
           "text": "Linkkien väri on Suomi.fi teemassa on sininen (highlightBase). Jos linkki on estetty, käytetään harmaata (depthBase). Linkit on Suomi.fi design systemissä esitetty ilman alleviivausta, jolloin linkki on hover-tilassa alleviivattu. Leipätekstin joukossa linkkitekstit alleviivataan, jotta ne erottuvat muusta tekstistä. Alleviivatut linkit ovat hover-tilassa ilman alleviivausta."
         },
         {
-            "image.key": "",
-            "image.alt": "",
-            "text": "Vierailun jälkeisessä tilassa (visited state) linkin väri on violetti (accentTertiaryDark9). Tila indikoidaan kaikissa linkeissä lukuunottamatta päänavigaation linkkejä ja käänteisiä linkkejä. Huomioi, että jos muokkaat linkkien tilojen värejä, on hyvä valita värit, jotka erottuvat riittävästi toisistaan. Linkeissä ei ole välttämätöntä käyttää vierailun jälkeiselle tilalle eri väriä, mutta sen käytön on todettu parantavan huomattavasti tekstiä sisältävien näkymien luettavuutta. Lisäksi näin pystytään indikoimaan selkeämmin listanäkymissä käyttäjän jo vierailemat sivut."
-          }
+          "image.key": "",
+          "image.alt": "",
+          "text": "Vierailun jälkeisessä tilassa (visited state) linkin väri on violetti (accentTertiaryDark9). Tila indikoidaan kaikissa linkeissä lukuunottamatta päänavigaation linkkejä ja käänteisiä linkkejä. Huomioi, että jos muokkaat linkkien tilojen värejä, on hyvä valita värit, jotka erottuvat riittävästi toisistaan. Linkeissä ei ole välttämätöntä käyttää vierailun jälkeiselle tilalle eri väriä, mutta sen käytön on todettu parantavan huomattavasti tekstiä sisältävien näkymien luettavuutta. Lisäksi näin pystytään indikoimaan selkeämmin listanäkymissä käyttäjän jo vierailemat sivut."
+        }
       ],
       "links": [
         {
@@ -76,4 +76,3 @@
   "exampleExternal.linkText": "Ulkoinen linkki",
   "exampleExternal.label": "Avautuu uuteen ikkunaan"
 }
-

--- a/src/components/ExampleComponents.tsx
+++ b/src/components/ExampleComponents.tsx
@@ -4,6 +4,7 @@ import {
   Breadcrumb as OrigBreadcrumb,
   Toggle as OrigToggle,
   Dropdown as OrigDropdown,
+  Link as OrigLink,
 } from 'suomifi-ui-components';
 import { addDisplayNames } from 'components/ExampleComponentUtil';
 
@@ -21,3 +22,6 @@ addDisplayNames(Toggle, OrigToggle, 'Toggle');
 
 export class Dropdown extends OrigDropdown {}
 addDisplayNames(Dropdown, OrigDropdown, 'Dropdown');
+
+export class Link extends OrigLink {}
+addDisplayNames(Link, OrigLink, 'Link');

--- a/src/config/sidenav/components.js
+++ b/src/config/sidenav/components.js
@@ -15,5 +15,6 @@ export default t => ({
     { to: '/components/breadcrumb/', label: t('breadcrumb:title') },
     { to: '/components/toggle/', label: t('toggle:title') },
     { to: '/components/dropdown/', label: t('dropdown:title') },
+    { to: '/components/link/', label: t('link:title') },
   ],
 });

--- a/src/pages/components/dropdown.tsx
+++ b/src/pages/components/dropdown.tsx
@@ -25,6 +25,7 @@ const Page = (): JSX.Element => (
         </Paragraph.lead>
 
         <ComponentDescription
+          exampleFirst={true}
           mainTitle={t('example.title')}
           description={t('example.description')}
         >

--- a/src/pages/components/dropdown.tsx
+++ b/src/pages/components/dropdown.tsx
@@ -25,7 +25,6 @@ const Page = (): JSX.Element => (
         </Paragraph.lead>
 
         <ComponentDescription
-          exampleFirst={true}
           mainTitle={t('example.title')}
           description={t('example.description')}
         >

--- a/src/pages/components/link.tsx
+++ b/src/pages/components/link.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import { NamespacesConsumer } from 'react-i18next';
+import { withI18next } from '@wapps/gatsby-plugin-i18next';
+
+import Layout from 'components/layout';
+import SEO from 'components/seo';
+import sideNavData from 'config/sidenav/components';
+import NoteBox from 'components/NoteBox';
+import Section from 'components/Section';
+import { Link as SuomifiLink, LinkExternal } from 'suomifi-ui-components';
+import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentExample from 'components/ComponentExample';
+
+const Page = (): JSX.Element => (
+  <NamespacesConsumer ns={['link']}>
+    {t => (
+      <Layout sideNavData={sideNavData(t)}>
+        <SEO title={t('title')} />
+        <Heading.h1>{t('title')}</Heading.h1>
+
+        <Paragraph.lead>
+          <Text.lead>{t('intro')}</Text.lead>
+        </Paragraph.lead>
+
+        <NoteBox title={t('note.title')} items={t('note.items')} />
+
+        {t('sections').map((section, index) => (
+          <Section
+            key={index}
+            mainTitle={section.title}
+            paragraphs={section.paragraphs}
+            links={section.links}
+          />
+        ))}
+        <ComponentDescription
+          mainTitle={t('exampleRegular.title')}
+          description={t('exampleRegular.description')}
+          exampleFirst={false}
+        >
+          <ComponentExample>
+            <SuomifiLink
+              className="test-classname"
+              href="www.esimerkkiosoite.com"
+            >
+              {t('exampleRegular.linkText')}
+            </SuomifiLink>
+          </ComponentExample>
+        </ComponentDescription>
+
+        <ComponentDescription
+          mainTitle={t('exampleExternal.title')}
+          description={t('exampleExternal.description')}
+          exampleFirst={false}
+        >
+          <ComponentExample>
+            <LinkExternal
+              className="test-classname"
+              href="www.esimerkkiosoite.com"
+              labelNewWindow={t('exampleExternal.label')}
+            >
+              {t('exampleExternal.linkText')}
+            </LinkExternal>
+          </ComponentExample>
+        </ComponentDescription>
+      </Layout>
+    )}
+  </NamespacesConsumer>
+);
+
+export default withI18next()(Page);
+
+export const query = graphql`
+  query($lng: String!) {
+    ...AllLocalesFragment
+  }
+`;

--- a/src/pages/components/link.tsx
+++ b/src/pages/components/link.tsx
@@ -8,7 +8,7 @@ import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
 import Section from 'components/Section';
-import { Link as SuomifiLink, LinkExternal } from 'suomifi-ui-components';
+import { Link as ExampleLink } from 'components/ExampleComponents';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
@@ -40,12 +40,9 @@ const Page = (): JSX.Element => (
           exampleFirst={false}
         >
           <ComponentExample>
-            <SuomifiLink
-              className="test-classname"
-              href="www.esimerkkiosoite.com"
-            >
+            <ExampleLink className="test-classname" href="#">
               {t('exampleRegular.linkText')}
-            </SuomifiLink>
+            </ExampleLink>
           </ComponentExample>
         </ComponentDescription>
 
@@ -55,13 +52,13 @@ const Page = (): JSX.Element => (
           exampleFirst={false}
         >
           <ComponentExample>
-            <LinkExternal
+            <ExampleLink.external
               className="test-classname"
-              href="www.esimerkkiosoite.com"
+              href="http://www.esimerkkiosoite.com"
               labelNewWindow={t('exampleExternal.label')}
             >
               {t('exampleExternal.linkText')}
-            </LinkExternal>
+            </ExampleLink.external>
           </ComponentExample>
         </ComponentDescription>
       </Layout>


### PR DESCRIPTION
Added a page for the link component under the component section. Proofread, adjusted and added content from the design team. Examples for regular link and external link added. The component itself is still missing some variants, which need to be added to the examples when implemented.