### PR TITLE
[Feature] Add heading page

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -133,3 +133,10 @@ minimum_perc = 0
 source_file = locale/af/link.json
 source_lang = af
 type = KEYVALUEJSON
+
+[suomifi-design-system.heading-json]
+file_filter = locale/<lang>/heading.json
+minimum_perc = 0
+source_file = locale/af/heading.json
+source_lang = af
+type = KEYVALUEJSON

--- a/locale/af/heading.json
+++ b/locale/af/heading.json
@@ -112,6 +112,7 @@
           }
         ]
       }
-    ]
+    ],
+    "example.title": "example.title"
   }
   

--- a/locale/af/heading.json
+++ b/locale/af/heading.json
@@ -1,118 +1,117 @@
 {
-    "title": "title",
-    "intro": "intro",
-    "note.title": "note.title",
-    "note.items": [
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item"
-    ],
-    "sections": [
-      {
-        "title": "section.title",
-        "paragraphs": [
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          },
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          },
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          }
-        ],
-        "links": [
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          },
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          },
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          }
-        ]
-      },
-      {
-        "title": "section.title",
-        "paragraphs": [
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          },
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          },
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          }
-        ],
-        "links": [
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          },
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          },
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          }
-        ]
-      },
-      {
-        "title": "section.title",
-        "paragraphs": [
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          },
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          },
-          {
-            "image.key": "section.paragraph.image.key",
-            "image.alt": "section.paragraph.image.alt",
-            "text": "section.paragraph.text"
-          }
-        ],
-        "links": [
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          },
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          },
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          }
-        ]
-      }
-    ],
-    "example.title": "example.title"
-  }
-  
+  "title": "title",
+  "intro": "intro",
+  "note.title": "note.title",
+  "note.items": [
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item"
+  ],
+  "sections": [
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        },
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        },
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        },
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        },
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        },
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        },
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    }
+  ],
+  "example.title": "example.title"
+}

--- a/locale/af/heading.json
+++ b/locale/af/heading.json
@@ -1,0 +1,117 @@
+{
+    "title": "title",
+    "intro": "intro",
+    "note.title": "note.title",
+    "note.items": [
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item",
+      "note.item"
+    ],
+    "sections": [
+      {
+        "title": "section.title",
+        "paragraphs": [
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          },
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          },
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          }
+        ],
+        "links": [
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          },
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          },
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          }
+        ]
+      },
+      {
+        "title": "section.title",
+        "paragraphs": [
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          },
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          },
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          }
+        ],
+        "links": [
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          },
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          },
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          }
+        ]
+      },
+      {
+        "title": "section.title",
+        "paragraphs": [
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          },
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          },
+          {
+            "image.key": "section.paragraph.image.key",
+            "image.alt": "section.paragraph.image.alt",
+            "text": "section.paragraph.text"
+          }
+        ],
+        "links": [
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          },
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          },
+          {
+            "text": "section.link.text",
+            "url": "section.link.url"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/locale/af/link.json
+++ b/locale/af/link.json
@@ -1,74 +1,77 @@
 {
-    "title": "title",
-    "intro": "intro",
-    "note.title": "note.title",
-    "note.items": [
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item",
-      "note.item"
-    ],
-    "sections": [
-      {
-        "title": "section.title",
-        "paragraphs": [
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": "section.paragraph.text"
-          }
-        ],
-        "links": [
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          }
-        ]
-      },
-      {
-        "title": "section.title",
-        "paragraphs": [
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": "section.paragraph.text"
-          }
-        ],
-        "links": [
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          }
-        ]
-      },
-      {
-        "title": "section.title",
-        "paragraphs": [
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": "section.paragraph.text"
-          }
-        ],
-        "links": [
-          {
-            "text": "section.link.text",
-            "url": "section.link.url"
-          }
-        ]
-      }
-    ],
-    "exampleRegular.title": "exampleRegular.title",
-    "exampleRegular.description": "exampleRegular.description",
-    "exampleRegular.linkText": "exampleRegular.linkText",
-    "exampleExternal.title": "exampleExternal.title",
-    "exampleExternal.description": "exampleExternal.description",
-    "exampleExternal.linkText": "exampleExternal.linkText",
-    "exampleExternal.label": "exampleExternal.label"
-    
-  }
-  
+  "title": "title",
+  "intro": "intro",
+  "note.title": "note.title",
+  "note.items": [
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item",
+    "note.item"
+  ],
+  "sections": [
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    }
+  ],
+  "exampleRegular.title": "exampleRegular.title",
+  "exampleRegular.description": "exampleRegular.description",
+  "exampleRegular.linkText": "exampleRegular.linkText",
+  "exampleExternal.title": "exampleExternal.title",
+  "exampleExternal.description": "exampleExternal.description",
+  "exampleExternal.linkText": "exampleExternal.linkText",
+  "exampleExternal.label": "exampleExternal.label"
+}

--- a/locale/fi/heading.json
+++ b/locale/fi/heading.json
@@ -6,10 +6,44 @@
     "Kuten näkevä käyttäjä, ruudunlukijakäyttäjäkin muodostaa kokonaiskäsityksen sisällöstä otsikoiden perusteella.",
     "Otsikointihierarkian tulee olla yhtenäinen (h1, h2, h3, h4, h5), eikä välistä saa puuttua otsikkotasoja. Oikea otsikkotasojen hierarkia tukee rakenteen hahmottamista.",
     "Otsikkotasojen puuttuminen välistä tai otsikkotasojen epäjärjestys vaikeuttaa sisällön hahmottamista ruudunlukijaa käytettäessä. Ruudunlukija tulkitsee vain heading-merkityt komponentit otsikoiksi.",
-    "Huomioi tekstiä koskevia WCGA 2.1 ohjeistuksia: 1.4.3 Contrast (Minimum), 4.4 Resize text, 1.4.12 Text Spacing.",
+    "Huomioi tekstiä koskevia WCGA 2.1 ohjeistuksia: 1.4.3 Contrast (Minimum), 1.4.4 Resize text, 1.4.12 Text Spacing.",
     ""
   ],
   "sections": [
+    {
+      "title": "",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        }
+      ],
+      "links": [
+        {
+          "text": "WCAG 2.1 vaatimukset",
+          "url": "https://www.w3.org/TR/WCAG21/"
+        },
+        {
+          "text": "",
+          "url": ""
+        },
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
     {
       "title": "Koko ja käyttö",
       "paragraphs": [

--- a/locale/fi/heading.json
+++ b/locale/fi/heading.json
@@ -1,0 +1,117 @@
+{
+    "title": "Otsikko (Heading)",
+    "intro": "Otsikot auttavat luomaan sivun sisällölle selkeän rakenteen, jonka avulla käyttäjä muodostaa kokonaiskäsityksen sivun sisällöstä.",
+    "note.title": "Saavutettavuus",
+    "note.items": [
+      "Kuten näkevä käyttäjä, ruudunlukijakäyttäjäkin muodostaa kokonaiskäsityksen sisällöstä otsikoiden perusteella.",
+      "Otsikointihierarkian tulee olla yhtenäinen (h1, h2, h3, h4, h5), eikä välistä saa puuttua otsikkotasoja. Oikea otsikkotasojen hierarkia tukee rakenteen hahmottamista.",
+      "Otsikkotasojen puuttuminen välistä tai otsikkotasojen epäjärjestys vaikeuttaa sisällön hahmottamista ruudunlukijaa käytettäessä. Ruudunlukija tulkitsee vain heading-merkityt komponentit otsikoiksi.",
+      "Huomioi tekstiä koskevia WCGA 2.1 ohjeistuksia: 1.4.3 Contrast (Minimum), 4.4 Resize text, 1.4.12 Text Spacing.",
+      ""
+    ],
+    "sections": [
+      {
+        "title": "Koko ja käyttö",
+        "paragraphs": [
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista. Enemmän Suomifi teeman typografiamäärittelyistä löytyy Tyylien alta."
+          },
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          },
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          }
+        ],
+        "links": [
+          {
+            "text": "",
+            "url": ""
+          },
+          {
+            "text": "",
+            "url": ""
+          },
+          {
+            "text": "",
+            "url": ""
+          }
+        ]
+      },
+      {
+        "title": "",
+        "paragraphs": [
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          },
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          },
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          }
+        ],
+        "links": [
+          {
+            "text": "",
+            "url": ""
+          },
+          {
+            "text": "",
+            "url": ""
+          },
+          {
+            "text": "",
+            "url": ""
+          }
+        ]
+      },
+      {
+        "title": "",
+        "paragraphs": [
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          },
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          },
+          {
+            "image.key": "",
+            "image.alt": "",
+            "text": ""
+          }
+        ],
+        "links": [
+          {
+            "text": "",
+            "url": ""
+          },
+          {
+            "text": "",
+            "url": ""
+          },
+          {
+            "text": "",
+            "url": ""
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/locale/fi/heading.json
+++ b/locale/fi/heading.json
@@ -1,119 +1,117 @@
 {
-    "title": "Otsikko (Heading)",
-    "intro": "Otsikot auttavat luomaan sivun sisällölle selkeän rakenteen, jonka avulla käyttäjä muodostaa kokonaiskäsityksen sivun sisällöstä.",
-    "note.title": "Saavutettavuus",
-    "note.items": [
-      "Kuten näkevä käyttäjä, ruudunlukijakäyttäjäkin muodostaa kokonaiskäsityksen sisällöstä otsikoiden perusteella.",
-      "Otsikointihierarkian tulee olla yhtenäinen (h1, h2, h3, h4, h5), eikä välistä saa puuttua otsikkotasoja. Oikea otsikkotasojen hierarkia tukee rakenteen hahmottamista.",
-      "Otsikkotasojen puuttuminen välistä tai otsikkotasojen epäjärjestys vaikeuttaa sisällön hahmottamista ruudunlukijaa käytettäessä. Ruudunlukija tulkitsee vain heading-merkityt komponentit otsikoiksi.",
-      "Huomioi tekstiä koskevia WCGA 2.1 ohjeistuksia: 1.4.3 Contrast (Minimum), 4.4 Resize text, 1.4.12 Text Spacing.",
-      ""
-    ],
-    "sections": [
-      {
-        "title": "Koko ja käyttö",
-        "paragraphs": [
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista."
-          },
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          },
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          }
-        ],
-        "links": [
-          {
-            "text": "Enemmän Suomi.fi teeman typografiamäärittelyistä löytyy Tyylien alta.",
-            "url": "/styles/typography"
-          },
-          {
-            "text": "",
-            "url": ""
-          },
-          {
-            "text": "",
-            "url": ""
-          }
-        ]
-      },
-      {
-        "title": "",
-        "paragraphs": [
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          },
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          },
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          }
-        ],
-        "links": [
-          {
-            "text": "",
-            "url": ""
-          },
-          {
-            "text": "",
-            "url": ""
-          },
-          {
-            "text": "",
-            "url": ""
-          }
-        ]
-      },
-      {
-        "title": "",
-        "paragraphs": [
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          },
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          },
-          {
-            "image.key": "",
-            "image.alt": "",
-            "text": ""
-          }
-        ],
-        "links": [
-          {
-            "text": "",
-            "url": ""
-          },
-          {
-            "text": "",
-            "url": ""
-          },
-          {
-            "text": "",
-            "url": ""
-          }
-        ]
-      }
-    ],
-    "example.title": "Suomi.fi teeman tukemat otsikkotyylit"
-  }
-
-  
+  "title": "Otsikko (Heading)",
+  "intro": "Otsikot auttavat luomaan sivun sisällölle selkeän rakenteen, jonka avulla käyttäjä muodostaa kokonaiskäsityksen sivun sisällöstä.",
+  "note.title": "Saavutettavuus",
+  "note.items": [
+    "Kuten näkevä käyttäjä, ruudunlukijakäyttäjäkin muodostaa kokonaiskäsityksen sisällöstä otsikoiden perusteella.",
+    "Otsikointihierarkian tulee olla yhtenäinen (h1, h2, h3, h4, h5), eikä välistä saa puuttua otsikkotasoja. Oikea otsikkotasojen hierarkia tukee rakenteen hahmottamista.",
+    "Otsikkotasojen puuttuminen välistä tai otsikkotasojen epäjärjestys vaikeuttaa sisällön hahmottamista ruudunlukijaa käytettäessä. Ruudunlukija tulkitsee vain heading-merkityt komponentit otsikoiksi.",
+    "Huomioi tekstiä koskevia WCGA 2.1 ohjeistuksia: 1.4.3 Contrast (Minimum), 4.4 Resize text, 1.4.12 Text Spacing.",
+    ""
+  ],
+  "sections": [
+    {
+      "title": "Koko ja käyttö",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista."
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        }
+      ],
+      "links": [
+        {
+          "text": "Enemmän Suomi.fi teeman typografiamäärittelyistä löytyy Tyylien alta.",
+          "url": "/styles/typography"
+        },
+        {
+          "text": "",
+          "url": ""
+        },
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
+    {
+      "title": "",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        },
+        {
+          "text": "",
+          "url": ""
+        },
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
+    {
+      "title": "",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        },
+        {
+          "text": "",
+          "url": ""
+        },
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    }
+  ],
+  "example.title": "Suomi.fi teeman tukemat otsikkotyylit"
+}

--- a/locale/fi/heading.json
+++ b/locale/fi/heading.json
@@ -16,7 +16,7 @@
           {
             "image.key": "",
             "image.alt": "",
-            "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista. Enemmän Suomifi teeman typografiamäärittelyistä löytyy Tyylien alta."
+            "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista. Enemmän Suomi.fi teeman typografiamäärittelyistä löytyy Tyylien alta."
           },
           {
             "image.key": "",

--- a/locale/fi/heading.json
+++ b/locale/fi/heading.json
@@ -16,7 +16,7 @@
           {
             "image.key": "",
             "image.alt": "",
-            "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista. Enemmän Suomi.fi teeman typografiamäärittelyistä löytyy Tyylien alta."
+            "text": "Otsikoiden koot on määritelty erikseen sekä desktop-, että mobiilinäytöille. Otsikot vaihtuvat normaalikoosta (Normal) pieneen kokoon (Small). Small-tyyppiset otsikkotyylit on määritelty erikokoisiksi kaikille muille otsikoille paitsi h5-otsikolle. Pääotsikolle on määritelty myös erillinen Hero-tyyli, jota käytetään erottamaan otsikkotyyli muiden sivujen pääotsikoista."
           },
           {
             "image.key": "",
@@ -31,8 +31,8 @@
         ],
         "links": [
           {
-            "text": "",
-            "url": ""
+            "text": "Enemmän Suomi.fi teeman typografiamäärittelyistä löytyy Tyylien alta.",
+            "url": "/styles/typography"
           },
           {
             "text": "",
@@ -112,6 +112,8 @@
           }
         ]
       }
-    ]
+    ],
+    "example.title": "Suomi.fi teeman tukemat otsikkotyylit"
   }
+
   

--- a/locale/fi/link.json
+++ b/locale/fi/link.json
@@ -1,6 +1,6 @@
 {
   "title": "Linkki (Link)",
-  "intro": "Linkkiä käytetään pääsääntöisesti navigaatioelementtinä",
+  "intro": "Linkkiä käytetään pääsääntöisesti navigaatioelementtinä.",
   "note.title": "Saavutettavuus ja käytettävyys",
   "note.items": [
     "Linkin tulee olla kuvaava ja sen tarkoituksen ymmärrettävissä pelkästä linkin nimestä.",
@@ -41,7 +41,7 @@
         {
           "image.key": "",
           "image.alt": "",
-          "text": "Linkit eroavat painikkeista siinä, että ne eivät muokkaa tietoa tai käynnistä toimintoa. Linkit vievät käyttäjän uuteen paikkaan käyttöliittymässä tai kokonaan pois sivustolta (External Link)"
+          "text": "Linkit eroavat painikkeista siinä, että ne eivät muokkaa tietoa tai käynnistä toimintoa. Linkit vievät käyttäjän uuteen paikkaan käyttöliittymässä tai kokonaan pois sivustolta (External Link)."
         }
       ],
       "links": [
@@ -72,7 +72,7 @@
   "exampleRegular.description": "Kirjasinkoko ja leikkaus on tasapainossa muun sisällön kanssa.",
   "exampleRegular.linkText": "Esimerkkilinkki",
   "exampleExternal.title": "Ulkoinen linkki (External link)",
-  "exampleExternal.description": "Linkeissä, jotka avautuvat uuteen ikkunaan on aina visuaalinen ja verbaalinen indikaatio",
+  "exampleExternal.description": "Linkeissä, jotka avautuvat uuteen ikkunaan on aina visuaalinen ja verbaalinen indikaatio.",
   "exampleExternal.linkText": "Ulkoinen linkki",
   "exampleExternal.label": "Avautuu uuteen ikkunaan"
 }

--- a/src/components/ExampleComponents.tsx
+++ b/src/components/ExampleComponents.tsx
@@ -5,6 +5,7 @@ import {
   Toggle as OrigToggle,
   Dropdown as OrigDropdown,
   Link as OrigLink,
+  Heading as OrigHeading,
 } from 'suomifi-ui-components';
 import { addDisplayNames } from 'components/ExampleComponentUtil';
 
@@ -25,3 +26,6 @@ addDisplayNames(Dropdown, OrigDropdown, 'Dropdown');
 
 export class Link extends OrigLink {}
 addDisplayNames(Link, OrigLink, 'Link');
+
+export class Heading extends OrigHeading {}
+addDisplayNames(Heading, OrigHeading, 'Heading');

--- a/src/config/sidenav/components.js
+++ b/src/config/sidenav/components.js
@@ -16,5 +16,6 @@ export default t => ({
     { to: '/components/toggle/', label: t('toggle:title') },
     { to: '/components/dropdown/', label: t('dropdown:title') },
     { to: '/components/link/', label: t('link:title') },
+    { to: '/components/heading/', label: t('heading:title') },
   ],
 });

--- a/src/pages/components/heading.tsx
+++ b/src/pages/components/heading.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import { NamespacesConsumer } from 'react-i18next';
+import { withI18next } from '@wapps/gatsby-plugin-i18next';
+
+import Layout from 'components/layout';
+import SEO from 'components/seo';
+import sideNavData from 'config/sidenav/components';
+import NoteBox from 'components/NoteBox';
+import Section from 'components/Section';
+import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentExample from 'components/ComponentExample';
+import { Heading as SuomifiHeading } from 'components/ExampleComponents';
+import { suomifiTheme } from 'suomifi-ui-components';
+
+const Page = (): JSX.Element => (
+  <NamespacesConsumer ns={['heading']}>
+    {t => (
+      <Layout sideNavData={sideNavData(t)}>
+        <SEO title={t('title')} />
+        <Heading.h1>{t('title')}</Heading.h1>
+
+        <Paragraph.lead>
+          <Text.lead>{t('intro')}</Text.lead>
+        </Paragraph.lead>
+
+        <NoteBox title={t('note.title')} items={t('note.items')} />
+
+        {t('sections').map((section, index) => (
+          <Section
+            key={index}
+            mainTitle={section.title}
+            paragraphs={section.paragraphs}
+            links={section.links}
+          />
+        ))}
+        <ComponentDescription
+          mainTitle={t('example.title')}
+          description={t('example.description')}
+          exampleFirst={false}
+        >
+          <ComponentExample
+            style={{
+              flexFlow: 'column',
+              alignItems: 'flex-start',
+              backgroundColor: suomifiTheme.colors.whiteBase,
+              border: `1px solid ${suomifiTheme.colors.depthLight13}`,
+            }}
+          >
+            <SuomifiHeading.h1hero
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading 1 with hero styling
+            </SuomifiHeading.h1hero>
+            <SuomifiHeading.h1>Heading h1</SuomifiHeading.h1>
+            <SuomifiHeading.h2>Heading h2</SuomifiHeading.h2>
+            <SuomifiHeading.h3>Heading h3</SuomifiHeading.h3>
+            <SuomifiHeading.h4>Heading h4</SuomifiHeading.h4>
+            <SuomifiHeading.h5>Heading h5</SuomifiHeading.h5>
+          </ComponentExample>
+
+          <ComponentExample />
+        </ComponentDescription>
+      </Layout>
+    )}
+  </NamespacesConsumer>
+);
+
+export default withI18next()(Page);
+
+export const query = graphql`
+  query($lng: String!) {
+    ...AllLocalesFragment
+  }
+`;

--- a/src/pages/components/heading.tsx
+++ b/src/pages/components/heading.tsx
@@ -37,15 +37,12 @@ const Page = (): JSX.Element => (
         ))}
         <ComponentDescription
           mainTitle={t('example.title')}
-          description={t('example.description')}
           exampleFirst={false}
         >
           <ComponentExample
             style={{
               flexFlow: 'column',
               alignItems: 'flex-start',
-              backgroundColor: suomifiTheme.colors.whiteBase,
-              border: `1px solid ${suomifiTheme.colors.depthLight13}`,
             }}
           >
             <SuomifiHeading.h1hero
@@ -53,14 +50,78 @@ const Page = (): JSX.Element => (
             >
               Heading 1 with hero styling
             </SuomifiHeading.h1hero>
-            <SuomifiHeading.h1>Heading h1</SuomifiHeading.h1>
-            <SuomifiHeading.h2>Heading h2</SuomifiHeading.h2>
-            <SuomifiHeading.h3>Heading h3</SuomifiHeading.h3>
-            <SuomifiHeading.h4>Heading h4</SuomifiHeading.h4>
-            <SuomifiHeading.h5>Heading h5</SuomifiHeading.h5>
+            <SuomifiHeading.h1
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h1
+            </SuomifiHeading.h1>
+            <SuomifiHeading.h2
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h2
+            </SuomifiHeading.h2>
+            <SuomifiHeading.h3
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h3
+            </SuomifiHeading.h3>
+            <SuomifiHeading.h4
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h4
+            </SuomifiHeading.h4>
+            <SuomifiHeading.h5
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h5
+            </SuomifiHeading.h5>
           </ComponentExample>
+        </ComponentDescription>
 
-          <ComponentExample />
+        <ComponentDescription>
+          <ComponentExample
+            style={{
+              flexFlow: 'column',
+              alignItems: 'flex-start',
+            }}
+          >
+            <SuomifiHeading.h1hero
+              smallScreen
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading 1 hero small screen
+            </SuomifiHeading.h1hero>
+            <SuomifiHeading.h1
+              smallScreen
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h1 small screen
+            </SuomifiHeading.h1>
+            <SuomifiHeading.h2
+              smallScreen
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h2 small screen
+            </SuomifiHeading.h2>
+            <SuomifiHeading.h3
+              smallScreen
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h3 small screen
+            </SuomifiHeading.h3>
+            <SuomifiHeading.h4
+              smallScreen
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h4 small screen
+            </SuomifiHeading.h4>
+            <SuomifiHeading.h5
+              smallScreen
+              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+            >
+              Heading h5 small screen
+            </SuomifiHeading.h5>
+          </ComponentExample>
         </ComponentDescription>
       </Layout>
     )}


### PR DESCRIPTION
Adds page presenting the heading component as per the design at https://app.goabstract.com/projects/3a1da570-1a2e-11e9-abe1-6b4306612e83/branches/ff7912c2-de11-4839-a857-412219dbddcc/commits/9d1827f30ecfa5dbeffd736e1e1ea3fa4128c6f8/files/C651C602-77CE-48B5-901D-D0AED36B4A0F/layers/886DD421-1C91-4FF5-9ABE-8BAB824989BD?mode=build&selected=921863136-9844BF13-B47C-4419-A246-B6C05135E69F

Also fixed a couple of small typos (missing periods) from the Link page.

Tested by running locally and test hooks.

