### PR TITLE
[Bugfix] Set component example background to white

### DIFF
--- a/src/components/ComponentExample.tsx
+++ b/src/components/ComponentExample.tsx
@@ -10,11 +10,12 @@ const ComponentExample = ({ style, children }: Props): JSX.Element => (
       flexWrap: 'wrap',
       padding: suomifiTheme.spacing.m,
       margin: `${suomifiTheme.spacing.m} 0`,
+      border: `1px solid ${suomifiTheme.colors.depthBase}`,
       ...style,
       background:
         style && style.background
           ? style.background
-          : suomifiTheme.colors.depthLight30,
+          : suomifiTheme.colors.whiteBase,
     }}
   >
     {children}

--- a/src/components/ComponentExample.tsx
+++ b/src/components/ComponentExample.tsx
@@ -15,7 +15,10 @@ const ComponentExample = ({ style, children }: Props): JSX.Element => (
         style && style.background
           ? style.background
           : suomifiTheme.colors.whiteBase,
-      border: style.border || `1px solid ${suomifiTheme.colors.depthBase}`,
+      border:
+        style && style.border
+          ? style.border
+          : `1px solid ${suomifiTheme.colors.depthBase}`,
     }}
   >
     {children}

--- a/src/components/ComponentExample.tsx
+++ b/src/components/ComponentExample.tsx
@@ -10,12 +10,12 @@ const ComponentExample = ({ style, children }: Props): JSX.Element => (
       flexWrap: 'wrap',
       padding: suomifiTheme.spacing.m,
       margin: `${suomifiTheme.spacing.m} 0`,
-      border: `1px solid ${suomifiTheme.colors.depthBase}`,
       ...style,
       background:
         style && style.background
           ? style.background
           : suomifiTheme.colors.whiteBase,
+      border: style.border || `1px solid ${suomifiTheme.colors.depthBase}`,
     }}
   >
     {children}

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -28,7 +28,6 @@ const components = [
     id: 'secondaryNoborder',
     comp: Button.secondaryNoborder,
     background: suomifiTheme.colors.whiteBase,
-    border: `1px solid ${suomifiTheme.colors.depthLight13}`,
   },
 ];
 
@@ -52,6 +51,8 @@ const disabledComponents = [
     comp: Button.secondaryNoborder,
   },
 ];
+
+const defaultBorder = `1px solid ${suomifiTheme.colors.depthBase}`;
 
 const clickCount = {};
 const handleClick = (id: string, name: string, t: Function): void => {
@@ -159,7 +160,7 @@ const Page = (): JSX.Element => (
               style={{
                 padding: suomifiTheme.spacing.s,
                 background: item.background,
-                border: item.border || 0,
+                border: item.border || defaultBorder,
               }}
             >
               {[
@@ -193,7 +194,7 @@ const Page = (): JSX.Element => (
               style={{
                 padding: suomifiTheme.spacing.s,
                 background: item.background,
-                border: item.border || 0,
+                border: item.border || defaultBorder,
               }}
             >
               {[

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -52,8 +52,6 @@ const disabledComponents = [
   },
 ];
 
-const defaultBorder = `1px solid ${suomifiTheme.colors.depthBase}`;
-
 const clickCount = {};
 const handleClick = (id: string, name: string, t: Function): void => {
   if (!clickCount[id]) {
@@ -122,9 +120,9 @@ const Page = (): JSX.Element => (
                 suomifiTheme.spacing.m
               }`,
               background: suomifiTheme.colors.whiteBase,
-              border: defaultBorder,
               display: 'flex',
               justifyContent: 'center',
+              border: `1px solid ${suomifiTheme.colors.depthBase}`,
             }}
           >
             <MobileDevice>
@@ -161,7 +159,7 @@ const Page = (): JSX.Element => (
               style={{
                 padding: suomifiTheme.spacing.s,
                 background: item.background,
-                border: item.border || defaultBorder,
+                border: item.border,
               }}
             >
               {[
@@ -195,7 +193,7 @@ const Page = (): JSX.Element => (
               style={{
                 padding: suomifiTheme.spacing.s,
                 background: item.background,
-                border: item.border || defaultBorder,
+                border: item.border,
               }}
             >
               {[

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -121,7 +121,8 @@ const Page = (): JSX.Element => (
               padding: `${suomifiTheme.spacing.l} ${suomifiTheme.spacing.m} 0 ${
                 suomifiTheme.spacing.m
               }`,
-              background: suomifiTheme.colors.depthLight30,
+              background: suomifiTheme.colors.whiteBase,
+              border: defaultBorder,
               display: 'flex',
               justifyContent: 'center',
             }}


### PR DESCRIPTION
## What was done

Adjusted component example background to be white (used to be gray) and added a gray border as per design. This was done by adjusting values in the ComponentExample component. The button page had some custom stylings, which were adjusted to match the new style.

## How was it tested

Tested by lint checks and by running locally