### PR TITLE
[Bugfix] Remove borders from icon and color examples

### DIFF
--- a/src/pages/styles/colors.tsx
+++ b/src/pages/styles/colors.tsx
@@ -173,6 +173,7 @@ const Page = (): JSX.Element => (
                 padding: 0,
                 justifyContent: 'flex-start',
                 background: 'none',
+                border: 'none',
               }}
             >
               {item.colors.map((color, index) =>

--- a/src/pages/styles/icons.tsx
+++ b/src/pages/styles/icons.tsx
@@ -85,6 +85,7 @@ const Page = (): JSX.Element => (
                 padding: 0,
                 justifyContent: 'flex-start',
                 background: 'none',
+                border: 'none',
               }}
             >
               {item.icons.map(icon => {


### PR DESCRIPTION
Recent addition of borders for component examples made icon and color example look slightly off. Added overriding styles removing the borders.