### PR TITLE
[Feature] Update to use suomifi-ui-components 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-syntax-highlighter": "^10.1.2",
     "styled-components": "^4.4.0",
     "suomifi-icons": "^0.0.10",
-    "suomifi-ui-components": "0.2.5"
+    "suomifi-ui-components": "0.4.0"
   },
   "resolutions": {
     "@wapps/gatsby-plugin-i18next/i18next": "^15.0.6",

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Link, { Props as LinkProps } from 'components/Link';
 import { Desktop, Mobile, Tablet } from 'components/Responsive';
 
 const linkStyle = {
-  padding: `${suomifiTheme.spacing.s} ${suomifiTheme.spacing.m}`,
-  border: `1px solid ${suomifiTheme.colors.whiteBase}`,
-  borderRadius: suomifiTheme.radius.basic,
+  padding: `${suomifiDesignTokens.spacing.s} ${suomifiDesignTokens.spacing.m}`,
+  border: `1px solid ${suomifiDesignTokens.colors.whiteBase}`,
+  borderRadius: '2px',
   '&:link,:visited,:focus,:hover,:active': {
     fontSize: '16px',
-    color: suomifiTheme.colors.whiteBase,
+    color: suomifiDesignTokens.colors.whiteBase,
     textDecoration: 'none',
   },
 };
@@ -42,7 +42,7 @@ const Content = ({
         color="whiteBase"
         style={{
           textAlign: 'inherit',
-          margin: `0 0 0 ${suomifiTheme.spacing.m}`,
+          margin: `0 0 0 ${suomifiDesignTokens.spacing.m}`,
         }}
       >
         {title}
@@ -50,9 +50,9 @@ const Content = ({
       {description && (
         <Paragraph
           style={{
-            margin: `${suomifiTheme.spacing.m} ${suomifiTheme.spacing.m} 0 ${
-              suomifiTheme.spacing.m
-            }`,
+            margin: `${suomifiDesignTokens.spacing.m} ${
+              suomifiDesignTokens.spacing.m
+            } 0 ${suomifiDesignTokens.spacing.m}`,
             textAlign: 'inherit',
           }}
         >
@@ -63,9 +63,9 @@ const Content = ({
     {link && !!link.text && !!link.url && (
       <div
         style={{
-          margin: `${suomifiTheme.spacing.m}`,
-          marginLeft: center ? 0 : suomifiTheme.spacing.m,
-          marginRight: center ? 0 : suomifiTheme.spacing.m,
+          margin: `${suomifiDesignTokens.spacing.m}`,
+          marginLeft: center ? 0 : suomifiDesignTokens.spacing.m,
+          marginRight: center ? 0 : suomifiDesignTokens.spacing.m,
         }}
       >
         <Link
@@ -83,8 +83,8 @@ const Annotation = ({ title, description, link }: Props): JSX.Element => (
   <div
     style={{
       margin: 0,
-      padding: suomifiTheme.spacing.m,
-      background: suomifiTheme.colors.highlightBase,
+      padding: suomifiDesignTokens.spacing.m,
+      background: suomifiDesignTokens.colors.highlightBase,
       display: 'flex',
       justifyContent: 'center',
     }}

--- a/src/components/BulletedList.tsx
+++ b/src/components/BulletedList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Text } from 'components/ResponsiveComponents';
 
@@ -12,7 +12,9 @@ const BulletedList = ({ items = [] }: Props): JSX.Element => {
 
   if (items.length > 0) {
     return (
-      <ul style={{ margin: 0, padding: `0 0 0 ${suomifiTheme.spacing.l}` }}>
+      <ul
+        style={{ margin: 0, padding: `0 0 0 ${suomifiDesignTokens.spacing.l}` }}
+      >
         {items.map((item, index) => (
           <li key={index}>
             <Text>{item.text}</Text>

--- a/src/components/BypassLink.tsx
+++ b/src/components/BypassLink.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from 'react';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
+import { focusOutline } from './utils/outline';
+
 const BypassLink = ({ to, children }: Props): JSX.Element => (
   <a
     href={to}
@@ -16,7 +18,7 @@ const BypassLink = ({ to, children }: Props): JSX.Element => (
         color: suomifiDesignTokens.colors.blackBase,
         textDecoration: 'none',
       },
-      // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
+      `&:focus { ${focusOutline} }`,
       { '&:focus': { position: 'absolute', left: 'auto' } },
     ]}
   >

--- a/src/components/BypassLink.tsx
+++ b/src/components/BypassLink.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const BypassLink = ({ to, children }: Props): JSX.Element => (
   <a
@@ -7,16 +7,16 @@ const BypassLink = ({ to, children }: Props): JSX.Element => (
     css={[
       {
         position: 'absolute',
-        zIndex: suomifiTheme.zindexes.focus + 1,
+        zIndex: 10000,
         left: '-1000px',
-        margin: suomifiTheme.spacing.m,
-        padding: suomifiTheme.spacing.s,
-        background: suomifiTheme.colors.highlightLight53,
-        border: `1px solid ${suomifiTheme.colors.depthLight13}`,
-        color: suomifiTheme.colors.blackBase,
+        margin: suomifiDesignTokens.spacing.m,
+        padding: suomifiDesignTokens.spacing.s,
+        background: suomifiDesignTokens.colors.highlightLight53,
+        border: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
+        color: suomifiDesignTokens.colors.blackBase,
         textDecoration: 'none',
       },
-      `&:focus { ${suomifiTheme.outlines.basic} }`,
+      // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
       { '&:focus': { position: 'absolute', left: 'auto' } },
     ]}
   >

--- a/src/components/ComponentCode.tsx
+++ b/src/components/ComponentCode.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, CSSProperties } from 'react';
 import reactElementToJSXString from 'react-element-to-jsx-string';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Highlighter = ({
   style,
@@ -34,7 +34,7 @@ const ComponentCode = ({
   filterProps,
   children,
 }: Props): JSX.Element => (
-  <div style={{ padding: suomifiTheme.spacing.m, ...style }}>
+  <div style={{ padding: suomifiDesignTokens.spacing.m, ...style }}>
     {!!javascript && (
       <Highlighter style={{ marginBottom: !children ? 0 : '1rem' }}>
         {javascript}

--- a/src/components/ComponentDescription.tsx
+++ b/src/components/ComponentDescription.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { NamespacesConsumer } from 'react-i18next';
-import { Panel, suomifiTheme } from 'suomifi-ui-components';
+import { Panel, suomifiDesignTokens } from 'suomifi-ui-components';
 import ComponentCode from 'components/ComponentCode';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -26,11 +26,11 @@ const ComponentDescription = ({
     {t => (
       <div
         style={{
-          marginBottom: suomifiTheme.spacing.l,
-          borderBottom: `1px solid ${suomifiTheme.colors.depthLight13}`,
+          marginBottom: suomifiDesignTokens.spacing.l,
+          borderBottom: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
         }}
       >
-        <div style={{ margin: `${suomifiTheme.spacing.l} 0` }}>
+        <div style={{ margin: `${suomifiDesignTokens.spacing.l} 0` }}>
           {!!mainTitle && <Heading.h2>{mainTitle}</Heading.h2>}
           {!!title && <Heading.h3>{title}</Heading.h3>}
         </div>
@@ -40,7 +40,7 @@ const ComponentDescription = ({
         </Paragraph>
         {!exampleFirst && <div>{children}</div>}
         {!noCode && (
-          <div style={{ margin: `${suomifiTheme.spacing.l} 0` }}>
+          <div style={{ margin: `${suomifiDesignTokens.spacing.l} 0` }}>
             <Panel.expansion title={t('common:react')} noPadding>
               {codeString && <ComponentCode javascript={codeString} />}
               {!showOnlyCodeString &&

--- a/src/components/ComponentExample.tsx
+++ b/src/components/ComponentExample.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, CSSProperties } from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const ComponentExample = ({ style, children }: Props): JSX.Element => (
   <div
@@ -8,17 +8,17 @@ const ComponentExample = ({ style, children }: Props): JSX.Element => (
       justifyContent: 'center',
       alignItems: 'center',
       flexWrap: 'wrap',
-      padding: suomifiTheme.spacing.m,
-      margin: `${suomifiTheme.spacing.m} 0`,
+      padding: suomifiDesignTokens.spacing.m,
+      margin: `${suomifiDesignTokens.spacing.m} 0`,
       ...style,
       background:
         style && style.background
           ? style.background
-          : suomifiTheme.colors.whiteBase,
+          : suomifiDesignTokens.colors.whiteBase,
       border:
         style && style.border
           ? style.border
-          : `1px solid ${suomifiTheme.colors.depthBase}`,
+          : `1px solid ${suomifiDesignTokens.colors.depthBase}`,
     }}
   >
     {children}

--- a/src/components/ContentBoxes.tsx
+++ b/src/components/ContentBoxes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { suomifiTheme, Icon } from 'suomifi-ui-components';
+import { suomifiDesignTokens, Icon } from 'suomifi-ui-components';
 import { StaticIconKeys } from 'suomifi-icons';
 
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
@@ -16,8 +16,8 @@ const Block = ({ block }: { block: Block }): JSX.Element => (
           justifyContent: 'center',
           width: '70px',
           height: '70px',
-          marginBottom: suomifiTheme.spacing.l,
-          border: `1px solid ${suomifiTheme.colors.depthLight13}`,
+          marginBottom: suomifiDesignTokens.spacing.l,
+          border: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
           borderRadius: '50%',
           fontSize: '50px',
         }}
@@ -35,7 +35,7 @@ const Block = ({ block }: { block: Block }): JSX.Element => (
         )}
       </div>
     ))}
-    <div style={{ margin: `${suomifiTheme.spacing.m} 0` }}>
+    <div style={{ margin: `${suomifiDesignTokens.spacing.m} 0` }}>
       <LinkList links={block.links} />
     </div>
   </>
@@ -49,8 +49,10 @@ const ContentBoxes = ({
 }: Props): JSX.Element => (
   <section
     style={{
-      background: hasFrame ? suomifiTheme.colors.whiteBase : 'none',
-      padding: `${suomifiTheme.spacing.l} ${suomifiTheme.spacing.m} 0`,
+      background: hasFrame ? suomifiDesignTokens.colors.whiteBase : 'none',
+      padding: `${suomifiDesignTokens.spacing.l} ${
+        suomifiDesignTokens.spacing.m
+      } 0`,
       display: 'flex',
       justifyContent: 'center',
     }}
@@ -59,7 +61,7 @@ const ContentBoxes = ({
       <Heading.h1
         style={{
           textAlign: 'left',
-          margin: `0 0 0 ${suomifiTheme.spacing.m}`,
+          margin: `0 0 0 ${suomifiDesignTokens.spacing.m}`,
         }}
       >
         {mainTitle}
@@ -69,7 +71,7 @@ const ContentBoxes = ({
           display: 'flex',
           flexWrap: 'wrap',
           justifyContent: 'center',
-          margin: `${suomifiTheme.spacing.l} 0 0 0`,
+          margin: `${suomifiDesignTokens.spacing.l} 0 0 0`,
         }}
       >
         <div
@@ -86,7 +88,7 @@ const ContentBoxes = ({
               key={index}
               style={{
                 flex: wrapAll ? '100%' : '30%',
-                margin: suomifiTheme.spacing.m,
+                margin: suomifiDesignTokens.spacing.m,
               }}
             >
               <Block block={block} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { NamespacesConsumer } from 'react-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Text, Paragraph } from 'components/ResponsiveComponents';
 import Link, { Props as LinkProps } from 'components/Link';
@@ -15,7 +15,7 @@ const Content = ({
   title,
   description,
   links,
-  background = suomifiTheme.colors.whiteBase,
+  background = suomifiDesignTokens.colors.whiteBase,
   textColor = 'blackBase',
   linkColor,
   textDecoration,
@@ -25,7 +25,7 @@ const Content = ({
   <div
     style={{
       margin: 0,
-      padding: suomifiTheme.spacing.m,
+      padding: suomifiDesignTokens.spacing.m,
       background: background,
       display: 'flex',
       justifyContent: 'center',
@@ -41,7 +41,7 @@ const Content = ({
       }}
     >
       {header && (
-        <div style={{ flex: '100%', marginTop: suomifiTheme.spacing.m }}>
+        <div style={{ flex: '100%', marginTop: suomifiDesignTokens.spacing.m }}>
           {header}
         </div>
       )}
@@ -55,8 +55,8 @@ const Content = ({
       </div>
       <div
         style={{
-          margin: `${suomifiTheme.spacing.m} 0`,
-          marginLeft: wrapAll ? 0 : suomifiTheme.spacing.xl,
+          margin: `${suomifiDesignTokens.spacing.m} 0`,
+          marginLeft: wrapAll ? 0 : suomifiDesignTokens.spacing.xl,
           flex: '50%',
           textAlign: center ? 'center' : 'initial',
         }}
@@ -94,9 +94,9 @@ const Content = ({
                         : 'flex-end',
                       flex: wrapAll ? '100%' : 'unset',
                       margin: wrapAll
-                        ? `${suomifiTheme.spacing.s} 0`
-                        : `0 ${suomifiTheme.spacing.m} ${
-                            suomifiTheme.spacing.m
+                        ? `${suomifiDesignTokens.spacing.s} 0`
+                        : `0 ${suomifiDesignTokens.spacing.m} ${
+                            suomifiDesignTokens.spacing.m
                           }`,
                     }}
                   >
@@ -107,7 +107,7 @@ const Content = ({
                       style={{
                         '&:link,:visited,:focus,:hover,:active': {
                           fontSize: '16px',
-                          color: suomifiTheme.colors[linkColor],
+                          color: suomifiDesignTokens.colors[linkColor],
                           textDecoration: textDecoration,
                         },
                       }}
@@ -153,7 +153,7 @@ const AllContent = ({
               icon: (
                 <Slack
                   style={{
-                    fill: suomifiTheme.colors.whiteBase,
+                    fill: suomifiDesignTokens.colors.whiteBase,
                     fontSize: '25px',
                   }}
                 />
@@ -165,7 +165,7 @@ const AllContent = ({
               icon: (
                 <Github
                   style={{
-                    fill: suomifiTheme.colors.whiteBase,
+                    fill: suomifiDesignTokens.colors.whiteBase,
                     fontSize: '25px',
                   }}
                 />
@@ -174,7 +174,7 @@ const AllContent = ({
               url: t('common:github.link.url'),
             },
           ]}
-          background={suomifiTheme.colors.brandBase}
+          background={suomifiDesignTokens.colors.brandBase}
           textColor="whiteBase"
           linkColor="whiteBase"
           textDecoration="underline"
@@ -206,8 +206,8 @@ interface Props {
   description: string;
   links?: LinkProps[];
   background?: string;
-  textColor?: keyof typeof suomifiTheme.colors;
-  linkColor?: keyof typeof suomifiTheme.colors;
+  textColor?: keyof typeof suomifiDesignTokens.colors;
+  linkColor?: keyof typeof suomifiDesignTokens.colors;
   textDecoration?: string;
   center?: boolean;
   wrapAll?: boolean;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import { Desktop, Mobile, Tablet } from 'components/Responsive';
@@ -17,7 +17,7 @@ const Content = ({
       margin: 0,
       padding: compact ? '2rem 1rem 5rem 1rem' : '6rem 1rem 8rem 1rem',
       background: `no-repeat center url(${Background}) ${
-        suomifiTheme.colors.brandBase
+        suomifiDesignTokens.colors.brandBase
       }`,
       backgroundSize: compact ? 'auto' : 'cover',
       display: 'flex',
@@ -36,7 +36,7 @@ const Content = ({
       <div>
         <SuomiFi
           style={{
-            fill: suomifiTheme.colors.whiteBase,
+            fill: suomifiDesignTokens.colors.whiteBase,
             fontSize: compact ? '30px' : '64px',
             margin: center ? '0 0 1rem' : '0 2rem 1rem 0',
           }}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Language } from '@wapps/gatsby-plugin-i18next';
 import { NamespacesConsumer } from 'react-i18next';
-import { Menu, MenuItem, Button, suomifiTheme } from 'suomifi-ui-components';
+import {
+  Menu,
+  MenuItem,
+  Button,
+  suomifiDesignTokens,
+} from 'suomifi-ui-components';
 
 const hasMultipleLanguages = ({ availableLngs }: Props): boolean =>
   !!availableLngs && availableLngs.length > 1;
@@ -38,7 +43,7 @@ const ListSwitcher = ({
       <ul
         aria-label={t('menu.label')}
         style={{
-          margin: suomifiTheme.spacing.m,
+          margin: suomifiDesignTokens.spacing.m,
           padding: 0,
           listStyle: 'none',
           display: 'flex',

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -57,7 +57,7 @@ const Link = ({ icon, text, title, url, style }: Props): JSX.Element => {
             hideIcon={!!icon}
             href={url}
             title={title}
-            aria-label={t('common:opens.new.window')}
+            labelNewWindow={t('common:opens.new.window')}
           >
             {content}
           </CustomLink>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,7 +1,10 @@
 import React, { ReactNode } from 'react';
 import { NamespacesConsumer } from 'react-i18next';
 import { Link as GatsbyLink } from '@wapps/gatsby-plugin-i18next';
-import { Link as SuomifiLink, suomifiTheme } from 'suomifi-ui-components';
+import {
+  Link as SuomifiLink,
+  suomifiDesignTokens,
+} from 'suomifi-ui-components';
 import styled from '@emotion/styled';
 
 import { ensureTrailingSlash } from 'components/LinkUtil';
@@ -26,7 +29,7 @@ const Link = ({ icon, text, title, url, style }: Props): JSX.Element => {
         <span
           style={{
             display: 'inline-flex',
-            marginRight: text ? suomifiTheme.spacing.s : 0,
+            marginRight: text ? suomifiDesignTokens.spacing.s : 0,
           }}
         >
           {icon}

--- a/src/components/LinkList.tsx
+++ b/src/components/LinkList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Link, { Props as LinkProps } from 'components/Link';
 
@@ -19,7 +19,10 @@ const LinkList = ({ links = [] }: Props): JSX.Element => {
     return (
       <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
         {links.map((link, index) => (
-          <li key={index} style={{ margin: `${suomifiTheme.spacing.m} 0` }}>
+          <li
+            key={index}
+            style={{ margin: `${suomifiDesignTokens.spacing.m} 0` }}
+          >
             <Link text={link.text} url={link.url} />
           </li>
         ))}

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, CSSProperties } from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 import { Location } from '@reach/router';
 
 import SideNavComp from 'components/SideNav';
@@ -37,7 +37,7 @@ const Content = ({
     id="main"
     style={{
       margin: hasFrame
-        ? `${suomifiTheme.spacing.l} ${suomifiTheme.spacing.m}`
+        ? `${suomifiDesignTokens.spacing.l} ${suomifiDesignTokens.spacing.m}`
         : 0,
       ...style,
     }}
@@ -53,9 +53,9 @@ const MainContent = ({
 }: Props): JSX.Element => (
   <div
     style={{
-      background: suomifiTheme.colors.depthLight30,
-      paddingTop: hasFrame ? suomifiTheme.spacing.m : 0,
-      paddingBottom: suomifiTheme.spacing.xl,
+      background: suomifiDesignTokens.colors.depthLight30,
+      paddingTop: hasFrame ? suomifiDesignTokens.spacing.m : 0,
+      paddingBottom: suomifiDesignTokens.spacing.xl,
     }}
   >
     <Desktop>
@@ -69,23 +69,28 @@ const MainContent = ({
         <div
           style={{
             margin: hasFrame
-              ? `${suomifiTheme.spacing.m} ${suomifiTheme.spacing.l} 0 ${
-                  suomifiTheme.spacing.l
-                }`
+              ? `${suomifiDesignTokens.spacing.m} ${
+                  suomifiDesignTokens.spacing.l
+                } 0 ${suomifiDesignTokens.spacing.l}`
               : 0,
             width: '100%',
             maxWidth: hasFrame ? 1140 : 'initial',
             display: 'flex',
             flexWrap: 'nowrap',
-            background: hasFrame ? suomifiTheme.colors.whiteBase : 'none',
+            background: hasFrame
+              ? suomifiDesignTokens.colors.whiteBase
+              : 'none',
             border: hasFrame
-              ? `1px solid ${suomifiTheme.colors.depthLight13}`
+              ? `1px solid ${suomifiDesignTokens.colors.depthLight13}`
               : 0,
           }}
         >
           <SideNav
             sideNavData={sideNavData}
-            style={{ width: '22rem', marginRight: suomifiTheme.spacing.m }}
+            style={{
+              width: '22rem',
+              marginRight: suomifiDesignTokens.spacing.m,
+            }}
           />
           <Content hasFrame={hasFrame} style={{ flex: 1 }}>
             {children}
@@ -97,20 +102,20 @@ const MainContent = ({
       <SideNav
         sideNavData={sideNavData}
         style={{
-          margin: `0 ${suomifiTheme.spacing.l}`,
-          border: `1px solid ${suomifiTheme.colors.depthLight13}`,
+          margin: `0 ${suomifiDesignTokens.spacing.l}`,
+          border: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
         }}
       />
       <div
         style={{
           margin: hasFrame
-            ? `${suomifiTheme.spacing.m} ${suomifiTheme.spacing.l} 0 ${
-                suomifiTheme.spacing.l
-              }`
+            ? `${suomifiDesignTokens.spacing.m} ${
+                suomifiDesignTokens.spacing.l
+              } 0 ${suomifiDesignTokens.spacing.l}`
             : 0,
-          background: hasFrame ? suomifiTheme.colors.whiteBase : 'none',
+          background: hasFrame ? suomifiDesignTokens.colors.whiteBase : 'none',
           border: hasFrame
-            ? `1px solid ${suomifiTheme.colors.depthLight13}`
+            ? `1px solid ${suomifiDesignTokens.colors.depthLight13}`
             : 0,
         }}
       >
@@ -121,17 +126,17 @@ const MainContent = ({
       <SideNav
         sideNavData={sideNavData}
         style={{
-          margin: `0 ${suomifiTheme.spacing.m}`,
-          border: `1px solid ${suomifiTheme.colors.depthLight13}`,
+          margin: `0 ${suomifiDesignTokens.spacing.m}`,
+          border: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
         }}
       />
       <div
         style={{
           margin: 0,
-          marginTop: hasFrame ? suomifiTheme.spacing.m : 0,
-          background: hasFrame ? suomifiTheme.colors.whiteBase : 'none',
+          marginTop: hasFrame ? suomifiDesignTokens.spacing.m : 0,
+          background: hasFrame ? suomifiDesignTokens.colors.whiteBase : 'none',
           border: hasFrame
-            ? `1px solid ${suomifiTheme.colors.depthLight13}`
+            ? `1px solid ${suomifiDesignTokens.colors.depthLight13}`
             : 0,
         }}
       >

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Icon, suomifiTheme, Button } from 'suomifi-ui-components';
+import { Icon, suomifiDesignTokens, Button } from 'suomifi-ui-components';
 import { NamespacesConsumer } from 'react-i18next';
 
 import MainMenuItem from 'components/MainMenuItem';
@@ -49,9 +49,15 @@ class MainMenu extends Component<Props, State> {
               onClick={this.toggleOpen}
             >
               {this.isOpen() ? (
-                <Icon icon="close" color={suomifiTheme.colors.depthDark27} />
+                <Icon
+                  icon="close"
+                  color={suomifiDesignTokens.colors.depthDark27}
+                />
               ) : (
-                <Icon icon="menu" color={suomifiTheme.colors.depthDark27} />
+                <Icon
+                  icon="menu"
+                  color={suomifiDesignTokens.colors.depthDark27}
+                />
               )}
             </Button>
             {this.isOpen() && (
@@ -60,11 +66,13 @@ class MainMenu extends Component<Props, State> {
                   position: 'absolute',
                   top: '50px',
                   right: 0,
-                  zIndex: suomifiTheme.zindexes.focus + 1,
+                  zIndex: 10000,
                   width: '20rem',
-                  background: suomifiTheme.colors.whiteBase,
-                  border: `1px solid ${suomifiTheme.colors.depthLight13}`,
-                  boxShadow: suomifiTheme.shadows.menuShadow,
+                  background: suomifiDesignTokens.colors.whiteBase,
+                  border: `1px solid ${
+                    suomifiDesignTokens.colors.depthLight13
+                  }`,
+                  // boxShadow: suomifiDesignTokens.shadows.menuShadow,
                 }}
               >
                 <nav aria-label={t('common:navigation.main')}>

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -5,6 +5,7 @@ import { NamespacesConsumer } from 'react-i18next';
 import MainMenuItem from 'components/MainMenuItem';
 import { MainNavData } from 'components/MainNavData';
 import LanguageSwitcher from 'components/LanguageSwitcher';
+import { menuShadow } from './utils/shadow';
 
 class MainMenu extends Component<Props, State> {
   public constructor(props: Props) {
@@ -72,7 +73,7 @@ class MainMenu extends Component<Props, State> {
                   border: `1px solid ${
                     suomifiDesignTokens.colors.depthLight13
                   }`,
-                  // boxShadow: suomifiDesignTokens.shadows.menuShadow,
+                  boxShadow: menuShadow,
                 }}
               >
                 <nav aria-label={t('common:navigation.main')}>

--- a/src/components/MainMenuItem.tsx
+++ b/src/components/MainMenuItem.tsx
@@ -1,8 +1,8 @@
 import React, { Component, ReactNode } from 'react';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 import { Link } from '@wapps/gatsby-plugin-i18next';
-
 import { isFrontPage } from 'components/LinkUtil';
+import { focusOutline } from './utils/outline';
 
 class MainMenuItem extends Component<Props> {
   public render(): JSX.Element {
@@ -30,7 +30,7 @@ class MainMenuItem extends Component<Props> {
               color: suomifiDesignTokens.colors.brandBase,
             },
           },
-          // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
+          `&:focus { ${focusOutline} }`,
         ]}
         getProps={({ isCurrent, isPartiallyCurrent }) => {
           if (!isFrontPage(to) && isPartiallyCurrent && !isCurrent) {

--- a/src/components/MainMenuItem.tsx
+++ b/src/components/MainMenuItem.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode } from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 import { Link } from '@wapps/gatsby-plugin-i18next';
 
 import { isFrontPage } from 'components/LinkUtil';
@@ -17,18 +17,20 @@ class MainMenuItem extends Component<Props> {
             alignItems: 'center',
             justifyContent: 'space-between',
             height: '3.2rem',
-            paddingLeft: suomifiTheme.spacing.m,
-            paddingRight: suomifiTheme.spacing.m,
-            borderBottom: `1px solid ${suomifiTheme.colors.depthSecondary}`,
-            color: suomifiTheme.colors.highlightBase,
+            paddingLeft: suomifiDesignTokens.spacing.m,
+            paddingRight: suomifiDesignTokens.spacing.m,
+            borderBottom: `1px solid ${
+              suomifiDesignTokens.colors.depthSecondary
+            }`,
+            color: suomifiDesignTokens.colors.highlightBase,
             textDecoration: 'none',
             whiteSpace: 'nowrap',
             '&:hover': {
-              background: suomifiTheme.colors.depthSecondary,
-              color: suomifiTheme.colors.brandBase,
+              background: suomifiDesignTokens.colors.depthSecondary,
+              color: suomifiDesignTokens.colors.brandBase,
             },
           },
-          `&:focus { ${suomifiTheme.outlines.basic} }`,
+          // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
         ]}
         getProps={({ isCurrent, isPartiallyCurrent }) => {
           if (!isFrontPage(to) && isPartiallyCurrent && !isCurrent) {
@@ -42,8 +44,8 @@ class MainMenuItem extends Component<Props> {
           if (isCurrent) {
             return {
               style: {
-                background: suomifiTheme.colors.depthSecondary,
-                color: suomifiTheme.colors.brandBase,
+                background: suomifiDesignTokens.colors.depthSecondary,
+                color: suomifiDesignTokens.colors.brandBase,
                 fontWeight: 600,
               },
             };

--- a/src/components/MobileDevice.tsx
+++ b/src/components/MobileDevice.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, CSSProperties } from 'react';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
+import { panelShadow } from './utils/shadow';
 
 const MobileDevice = ({ style, children }: Props): JSX.Element => (
   <div
@@ -8,7 +9,7 @@ const MobileDevice = ({ style, children }: Props): JSX.Element => (
       border: `.1rem solid ${suomifiDesignTokens.colors.depthDark27}`,
       borderBottom: 0,
       borderRadius: '1.5rem 1.5rem 0 0',
-      // boxShadow: suomifiDesignTokens.shadows.panelShadow,
+      boxShadow: panelShadow,
       padding: '2.5rem 1rem 0 1rem',
       margin: 0,
       background: suomifiDesignTokens.colors.depthLight13,

--- a/src/components/MobileDevice.tsx
+++ b/src/components/MobileDevice.tsx
@@ -1,17 +1,17 @@
 import React, { ReactNode, CSSProperties } from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const MobileDevice = ({ style, children }: Props): JSX.Element => (
   <div
     style={{
       width: '13rem',
-      border: `.1rem solid ${suomifiTheme.colors.depthDark27}`,
+      border: `.1rem solid ${suomifiDesignTokens.colors.depthDark27}`,
       borderBottom: 0,
       borderRadius: '1.5rem 1.5rem 0 0',
-      boxShadow: suomifiTheme.shadows.panelShadow,
+      // boxShadow: suomifiDesignTokens.shadows.panelShadow,
       padding: '2.5rem 1rem 0 1rem',
       margin: 0,
-      background: suomifiTheme.colors.depthLight13,
+      background: suomifiDesignTokens.colors.depthLight13,
     }}
   >
     <div
@@ -21,7 +21,7 @@ const MobileDevice = ({ style, children }: Props): JSX.Element => (
         margin: '0 auto',
         width: '3.5rem',
         height: '.25rem',
-        background: suomifiTheme.colors.depthDark27,
+        background: suomifiDesignTokens.colors.depthDark27,
         borderRadius: '.125rem',
       }}
     />

--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { Link } from '@wapps/gatsby-plugin-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
-
+import { focusOutline } from './utils/outline';
 import { isFrontPage } from 'components/LinkUtil';
 
 const NavItem = ({ to, children }: Props): JSX.Element => (
@@ -18,7 +18,7 @@ const NavItem = ({ to, children }: Props): JSX.Element => (
           borderBottom: `4px solid ${suomifiDesignTokens.colors.highlightBase}`,
         },
       },
-      // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
+      `&:focus { ${focusOutline} }`,
     ]}
     getProps={({ isCurrent, isPartiallyCurrent }) => {
       if (isCurrent || (!isFrontPage(to) && isPartiallyCurrent)) {

--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Link } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { isFrontPage } from 'components/LinkUtil';
 
@@ -9,22 +9,24 @@ const NavItem = ({ to, children }: Props): JSX.Element => (
     to={to}
     css={[
       {
-        padding: suomifiTheme.spacing.s,
+        padding: suomifiDesignTokens.spacing.s,
         lineHeight: '2.8rem',
         whiteSpace: 'nowrap',
-        color: suomifiTheme.colors.blackBase,
+        color: suomifiDesignTokens.colors.blackBase,
         textDecoration: 'none',
         '&:hover': {
-          borderBottom: `4px solid ${suomifiTheme.colors.highlightBase}`,
+          borderBottom: `4px solid ${suomifiDesignTokens.colors.highlightBase}`,
         },
       },
-      `&:focus { ${suomifiTheme.outlines.basic} }`,
+      // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
     ]}
     getProps={({ isCurrent, isPartiallyCurrent }) => {
       if (isCurrent || (!isFrontPage(to) && isPartiallyCurrent)) {
         return {
           style: {
-            borderBottom: `4px solid ${suomifiTheme.colors.highlightBase}`,
+            borderBottom: `4px solid ${
+              suomifiDesignTokens.colors.highlightBase
+            }`,
           },
         };
       }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NamespacesConsumer } from 'react-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import NavItem from 'components/NavItem';
 import { MainNavData } from 'components/MainNavData';
@@ -13,8 +13,8 @@ const Navigation = ({ mainNavData }: Props): JSX.Element => (
         style={{
           padding: 0,
           boxSizing: 'border-box',
-          background: `${suomifiTheme.colors.whiteBase}`,
-          borderBottom: `1px solid ${suomifiTheme.colors.depthLight13}`,
+          background: `${suomifiDesignTokens.colors.whiteBase}`,
+          borderBottom: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
           display: 'flex',
           justifyContent: 'center',
         }}
@@ -35,8 +35,8 @@ const Navigation = ({ mainNavData }: Props): JSX.Element => (
             <li
               key={item.to}
               style={{
-                margin: `0 ${suomifiTheme.spacing.l} 0 ${
-                  suomifiTheme.spacing.s
+                margin: `0 ${suomifiDesignTokens.spacing.l} 0 ${
+                  suomifiDesignTokens.spacing.s
                 }`,
               }}
             >

--- a/src/components/NoteBox.tsx
+++ b/src/components/NoteBox.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Heading, Text } from 'components/ResponsiveComponents';
 
 const NoteBox = ({ title, items }: Props): JSX.Element => (
   <section
     style={{
-      background: suomifiTheme.colors.highlightLight50,
-      margin: `${suomifiTheme.spacing.l} 0`,
-      padding: suomifiTheme.spacing.m,
-      border: `1px solid ${suomifiTheme.colors.depthLight13}`,
+      background: suomifiDesignTokens.colors.highlightLight50,
+      margin: `${suomifiDesignTokens.spacing.l} 0`,
+      padding: suomifiDesignTokens.spacing.m,
+      border: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
     }}
   >
     <Heading.h3 as="h2">{title}</Heading.h3>
-    <ul style={{ margin: 0, padding: `0 0 0 ${suomifiTheme.spacing.m}` }}>
+    <ul
+      style={{ margin: 0, padding: `0 0 0 ${suomifiDesignTokens.spacing.m}` }}
+    >
       {items.map(
         (item, index) =>
           !!item && (
-            <li key={index} style={{ margin: suomifiTheme.spacing.m }}>
+            <li key={index} style={{ margin: suomifiDesignTokens.spacing.m }}>
               <Text>{item}</Text>
             </li>
           ),

--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { suomifiTheme, Icon } from 'suomifi-ui-components';
+import { suomifiDesignTokens, Icon } from 'suomifi-ui-components';
 import { Text } from 'components/ResponsiveComponents';
 import { NamespacesConsumer } from 'react-i18next';
 
@@ -17,19 +17,19 @@ const NotificationBox = ({ style, notificationText }: Props): JSX.Element => (
           justifyContent: 'center',
           alignItems: 'center',
           flexWrap: 'wrap',
-          padding: suomifiTheme.spacing.l,
-          margin: `${suomifiTheme.spacing.m} 0`,
+          padding: suomifiDesignTokens.spacing.l,
+          margin: `${suomifiDesignTokens.spacing.m} 0`,
           ...style,
-          background: suomifiTheme.colors.accentSecondaryLight40,
+          background: suomifiDesignTokens.colors.accentSecondaryLight40,
           fontSize: '24px',
         }}
       >
-        <Icon icon="error" color={suomifiTheme.colors.accentSecondary} />
+        <Icon icon="error" color={suomifiDesignTokens.colors.accentSecondary} />
         <Text.bold
           style={{
-            marginLeft: suomifiTheme.spacing.m,
+            marginLeft: suomifiDesignTokens.spacing.m,
             verticalAlign: 'middle',
-            fontSize: suomifiTheme.typography.fontSize.body,
+            fontSize: suomifiDesignTokens.typography.bodyText,
           }}
         >
           {notificationText || t('common:work.in.progress.warning')}

--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -29,7 +29,9 @@ const NotificationBox = ({ style, notificationText }: Props): JSX.Element => (
           style={{
             marginLeft: suomifiDesignTokens.spacing.m,
             verticalAlign: 'middle',
-            fontSize: suomifiDesignTokens.typography.bodyText,
+            fontSize:
+              suomifiDesignTokens.values.typography.bodyText.fontSize.value +
+              suomifiDesignTokens.values.typography.bodyText.fontSize.unit,
           }}
         >
           {notificationText || t('common:work.in.progress.warning')}

--- a/src/components/Paragraph.tsx
+++ b/src/components/Paragraph.tsx
@@ -1,7 +1,7 @@
 import React, { Component, CSSProperties } from 'react';
 import {
   Paragraph as OrigParagraph,
-  suomifiTheme,
+  suomifiDesignTokens,
 } from 'suomifi-ui-components';
 
 import {
@@ -15,7 +15,7 @@ class CustomParagraph extends Component<Props> {
     return (
       <OrigParagraph
         style={{
-          margin: `${suomifiTheme.spacing.l} 0`,
+          margin: `${suomifiDesignTokens.spacing.l} 0`,
           lineHeight: smallScreen ? '28px' : '30px',
           ...style,
         }}
@@ -29,7 +29,7 @@ class CustomParagraph extends Component<Props> {
     return (
       <OrigParagraph
         style={{
-          margin: `${suomifiTheme.spacing.m} 0`,
+          margin: `${suomifiDesignTokens.spacing.m} 0`,
           lineHeight: '24px',
           ...style,
         }}
@@ -43,7 +43,7 @@ class CustomParagraph extends Component<Props> {
     return (
       <OrigParagraph
         style={{
-          margin: `${suomifiTheme.spacing.l} 0`,
+          margin: `${suomifiDesignTokens.spacing.l} 0`,
           lineHeight: '27px',
           ...style,
         }}

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Image } from 'components/Image';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
@@ -33,12 +33,12 @@ const Section = ({
             <Text>{paragraph.text}</Text>
           </Paragraph>
         )}
-        <div style={{ margin: `${suomifiTheme.spacing.l} 0` }}>
+        <div style={{ margin: `${suomifiDesignTokens.spacing.l} 0` }}>
           <BulletedList items={paragraph.listItems} />
         </div>
       </div>
     ))}
-    <div style={{ margin: `${suomifiTheme.spacing.l} 0` }}>
+    <div style={{ margin: `${suomifiDesignTokens.spacing.l} 0` }}>
       <LinkList links={links} />
     </div>
   </section>

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { suomifiTheme, Icon, Button, Text } from 'suomifi-ui-components';
+import { suomifiDesignTokens, Icon, Button, Text } from 'suomifi-ui-components';
 import { withPrefix } from 'gatsby';
 import { WindowLocation } from '@reach/router';
 
@@ -115,11 +115,13 @@ class SideNav extends Component<Props, State> {
     return (
       <div
         style={{
-          padding: suomifiTheme.spacing.s,
+          padding: suomifiDesignTokens.spacing.s,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          borderBottom: `1px solid ${suomifiTheme.colors.depthSecondary}`,
+          borderBottom: `1px solid ${
+            suomifiDesignTokens.colors.depthSecondary
+          }`,
           textShadow: 'none',
         }}
       >
@@ -127,7 +129,7 @@ class SideNav extends Component<Props, State> {
           <div style={{ fontSize: '40px', lineHeight: '1em' }}>
             {sideNavData.icon}
           </div>
-          <Text.bold style={{ marginLeft: suomifiTheme.spacing.s }}>
+          <Text.bold style={{ marginLeft: suomifiDesignTokens.spacing.s }}>
             {sideNavData.title}
           </Text.bold>
         </div>
@@ -136,7 +138,7 @@ class SideNav extends Component<Props, State> {
             style={{
               float: 'right',
               background: 'none',
-              marginRight: suomifiTheme.spacing.m,
+              marginRight: suomifiDesignTokens.spacing.m,
               padding: 0,
               border: 0,
               width: '16px',
@@ -145,7 +147,10 @@ class SideNav extends Component<Props, State> {
               transform: this.isNavOpen() ? 'rotate(.5turn)' : 'none',
             }}
           >
-            <Icon icon="chevronDown" color={suomifiTheme.colors.depthDark27} />
+            <Icon
+              icon="chevronDown"
+              color={suomifiDesignTokens.colors.depthDark27}
+            />
           </div>
         </MobileOrTablet>
       </div>
@@ -178,7 +183,7 @@ class SideNav extends Component<Props, State> {
                     ? this.isCurrent(item.to) ||
                       this.isPartiallyCurrent(item.showAsTo)
                     : this.isPartiallyCurrent(item.to))
-                    ? `4px solid ${suomifiTheme.colors.brandBase}`
+                    ? `4px solid ${suomifiDesignTokens.colors.brandBase}`
                     : 0
                   : 0,
             },
@@ -213,7 +218,7 @@ class SideNav extends Component<Props, State> {
           margin: 0,
           padding: 0,
           boxSizing: 'border-box',
-          background: `${suomifiTheme.colors.whiteBase}`,
+          background: `${suomifiDesignTokens.colors.whiteBase}`,
         }}
       >
         <Desktop>

--- a/src/components/SideNavItem.tsx
+++ b/src/components/SideNavItem.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ReactNode, MouseEvent } from 'react';
 import { suomifiDesignTokens, Icon, Button } from 'suomifi-ui-components';
 import { Link } from '@wapps/gatsby-plugin-i18next';
-
+import { focusOutline } from './utils/outline';
 import { isFrontPage } from 'components/LinkUtil';
 
 class SideNavItem extends Component<Props> {
@@ -44,7 +44,7 @@ class SideNavItem extends Component<Props> {
               color: suomifiDesignTokens.colors.brandBase,
             },
           },
-          // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
+          `&:focus { ${focusOutline} }`,
         ]}
         getProps={({ isCurrent, isPartiallyCurrent }) => {
           const isPartiallyCurrentPage = showAsTo

--- a/src/components/SideNavItem.tsx
+++ b/src/components/SideNavItem.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode, MouseEvent } from 'react';
-import { suomifiTheme, Icon, Button } from 'suomifi-ui-components';
+import { suomifiDesignTokens, Icon, Button } from 'suomifi-ui-components';
 import { Link } from '@wapps/gatsby-plugin-i18next';
 
 import { isFrontPage } from 'components/LinkUtil';
@@ -32,17 +32,19 @@ class SideNavItem extends Component<Props> {
             justifyContent: 'space-between',
             height: '3.2rem',
             paddingLeft: level + '.2rem',
-            paddingRight: suomifiTheme.spacing.s,
-            borderBottom: `1px solid ${suomifiTheme.colors.depthSecondary}`,
-            color: suomifiTheme.colors.highlightBase,
+            paddingRight: suomifiDesignTokens.spacing.s,
+            borderBottom: `1px solid ${
+              suomifiDesignTokens.colors.depthSecondary
+            }`,
+            color: suomifiDesignTokens.colors.highlightBase,
             textDecoration: 'none',
             textTransform: level === 1 ? 'uppercase' : 'none',
             '&:hover': {
-              background: suomifiTheme.colors.depthSecondary,
-              color: suomifiTheme.colors.brandBase,
+              background: suomifiDesignTokens.colors.depthSecondary,
+              color: suomifiDesignTokens.colors.brandBase,
             },
           },
-          `&:focus { ${suomifiTheme.outlines.basic} }`,
+          // `&:focus { ${suomifiDesignTokens.outlines.basic} }`,
         ]}
         getProps={({ isCurrent, isPartiallyCurrent }) => {
           const isPartiallyCurrentPage = showAsTo
@@ -60,8 +62,8 @@ class SideNavItem extends Component<Props> {
           if (isCurrent) {
             return {
               style: {
-                background: suomifiTheme.colors.depthSecondary,
-                color: suomifiTheme.colors.brandBase,
+                background: suomifiDesignTokens.colors.depthSecondary,
+                color: suomifiDesignTokens.colors.brandBase,
                 fontWeight: 600,
               },
             };
@@ -86,7 +88,10 @@ class SideNavItem extends Component<Props> {
             }}
             onClick={this.toggleOpen}
           >
-            <Icon icon="chevronDown" color={suomifiTheme.colors.depthDark27} />
+            <Icon
+              icon="chevronDown"
+              color={suomifiDesignTokens.colors.depthDark27}
+            />
           </Button>
         )}
       </Link>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NamespacesConsumer } from 'react-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import LanguageSwitcher from 'components/LanguageSwitcher';
 import { ReactComponent as SuomiFi } from 'staticIcons/SuomiFi.svg';
@@ -15,11 +15,11 @@ const Header = (): JSX.Element => (
     {t => (
       <header
         style={{
-          padding: suomifiTheme.spacing.m,
-          borderTop: `4px solid ${suomifiTheme.colors.brandBase}`,
+          padding: suomifiDesignTokens.spacing.m,
+          borderTop: `4px solid ${suomifiDesignTokens.colors.brandBase}`,
           boxSizing: `border-box`,
-          background: suomifiTheme.colors.whiteBase,
-          borderBottom: `1px solid ${suomifiTheme.colors.depthLight13}`,
+          background: suomifiDesignTokens.colors.whiteBase,
+          borderBottom: `1px solid ${suomifiDesignTokens.colors.depthLight13}`,
           display: 'flex',
           justifyContent: 'center',
           lineHeight: '40px',
@@ -52,14 +52,14 @@ const Header = (): JSX.Element => (
             style={{
               flex: 1,
               position: 'relative',
-              marginLeft: suomifiTheme.spacing.s,
+              marginLeft: suomifiDesignTokens.spacing.s,
             }}
           >
             <div
               style={{
                 fontSize: '28px',
                 fontWeight: 600,
-                color: suomifiTheme.colors.brandBase,
+                color: suomifiDesignTokens.colors.brandBase,
               }}
             >
               {t('common:header.title')}
@@ -74,7 +74,7 @@ const Header = (): JSX.Element => (
                 fontSize: '16px',
                 fontWeight: 600,
                 textTransform: 'uppercase',
-                color: suomifiTheme.colors.highlightBase,
+                color: suomifiDesignTokens.colors.highlightBase,
               }}
             >
               {t('common:header.stamp')}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { NamespacesConsumer } from 'react-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Header from 'components/header';
 import Navigation from 'components/Navigation';
@@ -36,10 +36,14 @@ const Layout = ({
     {t => (
       <div
         style={{
-          fontFamily: suomifiTheme.typography.fontFamily,
-          fontSize: suomifiTheme.typography.fontSize.body,
-          lineHeight: suomifiTheme.typography.lineHeight.body,
-          color: suomifiTheme.colors.blackBase,
+          fontFamily: suomifiDesignTokens.values.typography.bodyText.fontFamily,
+          fontSize:
+            suomifiDesignTokens.values.typography.bodyText.fontSize.value +
+            suomifiDesignTokens.values.typography.bodyText.fontSize.unit,
+          lineHeight:
+            suomifiDesignTokens.values.typography.bodyText.lineHeight.value +
+            suomifiDesignTokens.values.typography.bodyText.lineHeight.unit,
+          color: suomifiDesignTokens.colors.blackBase,
         }}
       >
         <BypassLinks hasSideNav={!!sideNavData} />

--- a/src/components/utils/outline.ts
+++ b/src/components/utils/outline.ts
@@ -1,0 +1,25 @@
+import { suomifiDesignTokens } from 'suomifi-ui-components';
+
+export const focusOutline = (): string => {
+  return `
+  outline: 0;
+  position: relative;
+    &:after {
+      content: '';
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      bottom: -4px;
+      left: -4px;
+      background-color: transparent;
+      box-sizing: border-box;
+      box-shadow: ${suomifiDesignTokens.colors.accentBase} 0px 0px 10px 0px;
+      z-index: 9999;
+      border-radius: 4px;
+      border-width: 1px;
+      border-style: solid;
+      border-color: ${suomifiDesignTokens.colors.accentBase} ;
+      border-image: initial;
+    }
+  `;
+};

--- a/src/components/utils/outline.ts
+++ b/src/components/utils/outline.ts
@@ -1,7 +1,6 @@
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
-export const focusOutline = (): string => {
-  return `
+export const focusOutline = `
   outline: 0;
   position: relative;
     &:after {
@@ -22,4 +21,3 @@ export const focusOutline = (): string => {
       border-image: initial;
     }
   `;
-};

--- a/src/components/utils/shadow.ts
+++ b/src/components/utils/shadow.ts
@@ -1,0 +1,3 @@
+export const menuShadow = `#29292933 0px 2px 3px 0px`;
+
+export const panelShadow = `#29292924 0px 1px 2px 0px, #2929291f 0px 1px 5px 0px`;

--- a/src/examples/customTheme.js
+++ b/src/examples/customTheme.js
@@ -1,8 +1,8 @@
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
-const gradients = { ...suomifiTheme.gradients };
+const gradients = { ...suomifiDesignTokens.gradients };
 gradients.highlightBase = '#09ae88';
 gradients.highlightLight4 = '#e97025';
 gradients.highlightDark9 = '#faaf00';
 
-export const customTheme = { ...suomifiTheme, gradients };
+export const customTheme = { ...suomifiDesignTokens, gradients };

--- a/src/examples/styles.js
+++ b/src/examples/styles.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
+import { panelShadow } from '../components/utils/shadow';
 
 export const Example = () => (
   <div
@@ -7,6 +8,7 @@ export const Example = () => (
       margin: suomifiDesignTokens.spacing.l,
       padding: suomifiDesignTokens.spacing.m,
       background: suomifiDesignTokens.colors.highlightBase,
+      boxShadow: panelShadow,
       fontSize:
         suomifiDesignTokens.values.typography.bodyText.fontSize.value +
         suomifiDesignTokens.values.typography.bodyText.fontSize.unit,

--- a/src/examples/styles.js
+++ b/src/examples/styles.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 export const Example = () => (
   <div
     style={{
-      margin: suomifiTheme.spacing.l,
-      padding: suomifiTheme.spacing.m,
-      borderRadius: suomifiTheme.radius.basic,
-      background: suomifiTheme.colors.highlightBase,
-      boxShadow: suomifiTheme.shadows.panelShadow,
-      fontSize: suomifiTheme.typography.fontSize.body,
-      color: suomifiTheme.colors.whiteBase,
+      margin: suomifiDesignTokens.spacing.l,
+      padding: suomifiDesignTokens.spacing.m,
+      background: suomifiDesignTokens.colors.highlightBase,
+      fontSize:
+        suomifiDesignTokens.values.typography.bodyText.fontSize.value +
+        suomifiDesignTokens.values.typography.bodyText.fontSize.unit,
+      color: suomifiDesignTokens.colors.whiteBase,
     }}
   >
     Example

--- a/src/pages/accessibility-statement.tsx
+++ b/src/pages/accessibility-statement.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { NamespacesConsumer } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -13,7 +13,7 @@ const Page = (): JSX.Element => (
   <NamespacesConsumer ns={['accessibility-statement']}>
     {t => (
       <Layout>
-        <div style={{ padding: `0 ${suomifiTheme.spacing.l}` }}>
+        <div style={{ padding: `0 ${suomifiDesignTokens.spacing.l}` }}>
           <SEO title={t('title')} />
           <Heading variant="h1">{t('title')}</Heading>
           {t('sections').map((section, index) => (

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { NamespacesConsumer } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -21,13 +21,13 @@ const components = [
   {
     id: 'negative',
     comp: Button.negative,
-    background: suomifiTheme.colors.highlightBase,
+    background: suomifiDesignTokens.colors.highlightBase,
   },
   { id: 'secondary', comp: Button.secondary },
   {
     id: 'secondaryNoborder',
     comp: Button.secondaryNoborder,
-    background: suomifiTheme.colors.whiteBase,
+    background: suomifiDesignTokens.colors.whiteBase,
   },
 ];
 
@@ -43,7 +43,7 @@ const disabledComponents = [
   {
     id: 'negative',
     comp: Button.negative,
-    background: suomifiTheme.colors.highlightBase,
+    background: suomifiDesignTokens.colors.highlightBase,
   },
   { id: 'secondary', comp: Button.secondary },
   {
@@ -77,7 +77,7 @@ const getExampleComp = (
     key={id}
     id={id}
     aria-label={label}
-    style={{ margin: suomifiTheme.spacing.s }}
+    style={{ margin: suomifiDesignTokens.spacing.s }}
     {...props}
     onClick={() => handleClick(id, label, t)}
   >
@@ -115,14 +115,14 @@ const Page = (): JSX.Element => (
           <div
             style={{
               overflow: 'hidden',
-              marginBottom: suomifiTheme.spacing.m,
-              padding: `${suomifiTheme.spacing.l} ${suomifiTheme.spacing.m} 0 ${
-                suomifiTheme.spacing.m
-              }`,
-              background: suomifiTheme.colors.whiteBase,
+              marginBottom: suomifiDesignTokens.spacing.m,
+              padding: `${suomifiDesignTokens.spacing.l} ${
+                suomifiDesignTokens.spacing.m
+              } 0 ${suomifiDesignTokens.spacing.m}`,
+              background: suomifiDesignTokens.colors.whiteBase,
               display: 'flex',
               justifyContent: 'center',
-              border: `1px solid ${suomifiTheme.colors.depthBase}`,
+              border: `1px solid ${suomifiDesignTokens.colors.depthBase}`,
             }}
           >
             <MobileDevice>
@@ -130,8 +130,8 @@ const Page = (): JSX.Element => (
                 <div
                   key={item.id}
                   style={{
-                    padding: `${suomifiTheme.spacing.m} ${
-                      suomifiTheme.spacing.s
+                    padding: `${suomifiDesignTokens.spacing.m} ${
+                      suomifiDesignTokens.spacing.s
                     }`,
                   }}
                 >
@@ -157,7 +157,7 @@ const Page = (): JSX.Element => (
           >
             <ComponentExample
               style={{
-                padding: suomifiTheme.spacing.s,
+                padding: suomifiDesignTokens.spacing.s,
                 background: item.background,
                 border: item.border,
               }}
@@ -191,7 +191,7 @@ const Page = (): JSX.Element => (
             <ComponentExample
               key={item.id}
               style={{
-                padding: suomifiTheme.spacing.s,
+                padding: suomifiDesignTokens.spacing.s,
                 background: item.background,
                 border: item.border,
               }}
@@ -229,12 +229,12 @@ const Page = (): JSX.Element => (
           description={t('disabled.description')}
           exampleFirst
         >
-          <ComponentExample style={{ padding: suomifiTheme.spacing.s }}>
+          <ComponentExample style={{ padding: suomifiDesignTokens.spacing.s }}>
             {disabledComponents.map(item => (
               <div
                 key={item.id}
                 style={{
-                  padding: item.background ? suomifiTheme.spacing.s : 0,
+                  padding: item.background ? suomifiDesignTokens.spacing.s : 0,
                   background: item.background || 'none',
                 }}
               >

--- a/src/pages/components/heading.tsx
+++ b/src/pages/components/heading.tsx
@@ -12,7 +12,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
 import { Heading as SuomifiHeading } from 'components/ExampleComponents';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
   <NamespacesConsumer ns={['heading']}>
@@ -46,32 +46,32 @@ const Page = (): JSX.Element => (
             }}
           >
             <SuomifiHeading.h1hero
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading 1 with hero styling
             </SuomifiHeading.h1hero>
             <SuomifiHeading.h1
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h1
             </SuomifiHeading.h1>
             <SuomifiHeading.h2
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h2
             </SuomifiHeading.h2>
             <SuomifiHeading.h3
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h3
             </SuomifiHeading.h3>
             <SuomifiHeading.h4
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h4
             </SuomifiHeading.h4>
             <SuomifiHeading.h5
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h5
             </SuomifiHeading.h5>
@@ -87,37 +87,37 @@ const Page = (): JSX.Element => (
           >
             <SuomifiHeading.h1hero
               smallScreen
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading 1 hero small screen
             </SuomifiHeading.h1hero>
             <SuomifiHeading.h1
               smallScreen
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h1 small screen
             </SuomifiHeading.h1>
             <SuomifiHeading.h2
               smallScreen
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h2 small screen
             </SuomifiHeading.h2>
             <SuomifiHeading.h3
               smallScreen
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h3 small screen
             </SuomifiHeading.h3>
             <SuomifiHeading.h4
               smallScreen
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h4 small screen
             </SuomifiHeading.h4>
             <SuomifiHeading.h5
               smallScreen
-              style={{ margin: `${suomifiTheme.spacing.s} 0` }}
+              style={{ margin: `${suomifiDesignTokens.spacing.s} 0` }}
             >
               Heading h5 small screen
             </SuomifiHeading.h5>

--- a/src/pages/components/panel.tsx
+++ b/src/pages/components/panel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { NamespacesConsumer } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -47,9 +47,9 @@ const Page = (): JSX.Element => (
               <p
                 style={{
                   margin: 0,
-                  padding: suomifiTheme.spacing.m,
-                  background: suomifiTheme.colors.brandBase,
-                  color: suomifiTheme.colors.whiteBase,
+                  padding: suomifiDesignTokens.spacing.m,
+                  background: suomifiDesignTokens.colors.brandBase,
+                  color: suomifiDesignTokens.colors.whiteBase,
                 }}
               >
                 {t('panel.content')}

--- a/src/pages/components/text.tsx
+++ b/src/pages/components/text.tsx
@@ -7,7 +7,6 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
-import NotificationBox from 'components/NotificationBox';
 import Section from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Paragraph } from 'components/ResponsiveComponents';
@@ -52,8 +51,6 @@ const Page: React.FC = (): React.ReactElement => {
           <Paragraph.lead>
             <Text.lead>{t('intro')}</Text.lead>
           </Paragraph.lead>
-
-          <NotificationBox />
 
           {t('sections').map((section, index) => (
             <Section

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { NamespacesConsumer } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -26,7 +26,7 @@ const Page = (): JSX.Element => (
             icon: (
               <Slack
                 style={{
-                  fill: suomifiTheme.colors.whiteBase,
+                  fill: suomifiDesignTokens.colors.whiteBase,
                   fontSize: '16px',
                 }}
               />

--- a/src/pages/styles/colors.tsx
+++ b/src/pages/styles/colors.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from 'react';
 import { graphql } from 'gatsby';
 import { NamespacesConsumer } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 import { getLuminance } from 'polished';
 
 import Layout from 'components/layout';
@@ -15,13 +15,13 @@ import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
 const colorTokens =
-  !!suomifiTheme && !!suomifiTheme.colors
-    ? suomifiTheme.colors
+  !!suomifiDesignTokens && !!suomifiDesignTokens.colors
+    ? suomifiDesignTokens.colors
     : { depthLight13: undefined };
 
 const borderForLightColor = `1px solid ${colorTokens.depthLight13}`;
 
-type ColorKeys = keyof typeof suomifiTheme.colors;
+type ColorKeys = keyof typeof suomifiDesignTokens.colors;
 interface ColorItem {
   name: string;
   value: string;
@@ -117,9 +117,9 @@ const getExampleColor = (
   <div
     key={id}
     style={{
-      margin: `${suomifiTheme.spacing.s} ${suomifiTheme.spacing.l} ${
-        suomifiTheme.spacing.l
-      } 0`,
+      margin: `${suomifiDesignTokens.spacing.s} ${
+        suomifiDesignTokens.spacing.l
+      } ${suomifiDesignTokens.spacing.l} 0`,
       lineHeight: '1rem',
     }}
   >
@@ -127,7 +127,7 @@ const getExampleColor = (
       style={{
         width: '10rem',
         height: '3rem',
-        marginBottom: suomifiTheme.spacing.m,
+        marginBottom: suomifiDesignTokens.spacing.m,
         background: value,
         ...style,
       }}

--- a/src/pages/styles/icons.tsx
+++ b/src/pages/styles/icons.tsx
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby';
 import styled from 'styled-components';
 import { NamespacesConsumer } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { suomifiTheme, Icon } from 'suomifi-ui-components';
+import { suomifiDesignTokens, Icon } from 'suomifi-ui-components';
 import {
   allIcons,
   IconKeys,
@@ -43,9 +43,9 @@ const getExampleIcon = (
   <div
     key={id}
     style={{
-      margin: `${suomifiTheme.spacing.s} ${suomifiTheme.spacing.xl} ${
-        suomifiTheme.spacing.l
-      } 0`,
+      margin: `${suomifiDesignTokens.spacing.s} ${
+        suomifiDesignTokens.spacing.xl
+      } ${suomifiDesignTokens.spacing.l} 0`,
       lineHeight: '1rem',
       display: 'flex',
       flexDirection: 'column',
@@ -105,7 +105,7 @@ const Page = (): JSX.Element => (
             icon: (
               <Slack
                 style={{
-                  fill: suomifiTheme.colors.whiteBase,
+                  fill: suomifiDesignTokens.colors.whiteBase,
                   fontSize: '16px',
                 }}
               />

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,10 +788,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@csstools/normalize.css@9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
-  integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
+"@csstools/normalize.css@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
+  integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@csstools/normalize.css@^10.0.0":
   version "10.0.0"
@@ -996,12 +996,12 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-"@j-kallunki/css-in-to-js@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@j-kallunki/css-in-to-js/-/css-in-to-js-1.0.3.tgz#27a5f89c6565bc00e7e717f3674f2c5ee18930d4"
-  integrity sha512-wys/d3YToyujiPgN531eScXxl2oHm5kbXXGLAtaY0Kgvl9WfNkw2hmdvjhCjBqfG1MThRtu+PLHdVDSPBFO3OQ==
+"@j-kallunki/css-in-to-js@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@j-kallunki/css-in-to-js/-/css-in-to-js-1.0.5.tgz#0ce3aec875b16817c0e702260cc73eb198f44200"
+  integrity sha512-1u1B41D7urc4HkSjkPeM53BMfENFzjJ4nhfQo17njA87ZRtbf/dx0Q3Zl9X4yTIT8jrnln2k7i/tLfgpCXRciQ==
   dependencies:
-    lodash "4.17.11"
+    lodash "4.17.15"
     postcss "7.0.5"
 
 "@mikaelkristiansson/domready@^1.0.9":
@@ -9416,7 +9416,12 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -10399,13 +10404,13 @@ normalize-url@^3.0.0, normalize-url@^3.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-normalize.cssinjs@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/normalize.cssinjs/-/normalize.cssinjs-1.0.5.tgz#53cae9500920792e91bed369bc21b5c62cb93d02"
-  integrity sha512-4JoDvhYmYrYm86uVRBLDWhmqR2iuKx3qE0/Y+e8AuqfuIuA2E385ZA6jKgaPXYCtKK7ZwVfCvP4xYrvOtzefHA==
+normalize.cssinjs@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/normalize.cssinjs/-/normalize.cssinjs-1.1.0.tgz#d60576c44f31e9f76570e3318b94ae3916ee6b94"
+  integrity sha512-mXioiaurR20LtLfrERtsQ4IsMJeDpY22BVKIrgrxoTc51rW8S+kIFvs+p3Y5KmIKTQ8X3dKC2SOZSB5CfVRH3A==
   dependencies:
-    "@csstools/normalize.css" "9.0.1"
-    "@j-kallunki/css-in-to-js" "1.0.3"
+    "@csstools/normalize.css" "10.1.0"
+    "@j-kallunki/css-in-to-js" "1.0.5"
 
 npm-bundled@^1.0.1:
   version "1.0.6"
@@ -14325,31 +14330,32 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-suomifi-icons@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.8.tgz#2a25de59b9e945321d504c0c393f8371d8213bbb"
-  integrity sha512-C/qsOpERN73eyAMjpOMtGPw2NkS1R57VVk/cjsxM7mmlDMiBYjCdXM8XYa3HPsGxlznEHxNmCxWqMf4z/QF1WA==
+suomifi-design-tokens@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.6.0.tgz#a849e6a1115df18beff82b74c7835586fcf19814"
+  integrity sha512-1His7iGBynkEzUI9uhMDGHCYQeFUh+kfbOsqdn4rMz8v9Vqpx/5QngTs3UstK85mjJzaZrN0Q7bdTcRtVCkrWA==
 
-suomifi-icons@^0.0.10:
+suomifi-icons@0.0.10, suomifi-icons@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.10.tgz#d2e32f7e03c53b86d1efeeada037a0f420a01804"
   integrity sha512-tPh7CFBOGyyK0qaBU7dlOsHn9c8hLi0qpNHXz2xhHbVOkPD6bGLDlrtkQVdvni5nRi9zYJ2xeiaSZ7azADTeLQ==
 
-suomifi-ui-components@0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/suomifi-ui-components/-/suomifi-ui-components-0.2.5.tgz#c6c0acd02ee1af499141f4bf708f053955c4443f"
-  integrity sha512-VU2FxB8GdaPPWVLnaOIBduwbMHnZgejPwjysBRRoosRCHif7L480vF2Yw0atrGtB4gg9/Th4UceDd8gG9SxqJg==
+suomifi-ui-components@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/suomifi-ui-components/-/suomifi-ui-components-0.4.0.tgz#957f444988e2f6acd3e854182d279d89ba3a5b06"
+  integrity sha512-j2dITI/pKYOC1PB3jnA8bGSIGo/dWi6Kv23hLqFbnionYpnn2E48gdbsHWBFjw7QKhOu5s0BQ761c89oOl+Kkg==
   dependencies:
     "@emotion/core" "10.0.0"
     "@emotion/styled" "10.0.0"
     "@reach/component-component" "0.1.3"
     "@reach/menu-button" "0.1.7"
     classnames "2.2.6"
-    normalize.cssinjs "1.0.5"
+    normalize.cssinjs "1.1.0"
     polished "3.4.0"
     react-svg "7.2.2"
     styled-components "4.3.2"
-    suomifi-icons "0.0.8"
+    suomifi-design-tokens "0.6.0"
+    suomifi-icons "0.0.10"
     uuid "3.3.2"
 
 supports-color@^2.0.0:


### PR DESCRIPTION
Updated to use `suomifi-ui-components` **0.4.0** which had breaking changes regarding design tokens.

Created few utils/helpers(?) that can be removed when `suomifi-ui-components` have the needed components to be used on the DS-site:

- src/components/utils/shadow.ts
  - `panelShadow` & `menuShadow` that are no longer available from the tokens
- src/components/utils/outline.ts
  - `focusOutline` that is no longer available from the tokens

Other changes:
- Fixed external link to use the new 'labelNewWindow' prop
- Removed WIP (NotificationBox) from the Text-component's page

**How it was tested**
- Using `yarn validate`
- Manually in the browser comparing to previous version of the DS-site