### PR TITLE
[Bugfix] Fix name in transifex config file

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -148,7 +148,7 @@ source_file = locale/af/text.json
 source_lang = af
 type = KEYVALUEJSON
 
-[suomifi-design-system.text-json]
+[suomifi-design-system.textinput-json]
 file_filter = locale/<lang>/textinput.json
 minimum_perc = 0
 source_file = locale/af/textinput.json


### PR DESCRIPTION
Fixed a conflicting name in transifex configuration. Translations hadn't been pushed to transifex yet so it shouldn't have affected anything.