### PR TITLE
[Feature]Update react-i18next, i18next + some other minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^16.13.1",
     "react-element-to-jsx-string": "^14.3.1",
     "react-helmet": "^5.2.1",
-    "react-i18next": "^8.4.0",
+    "react-i18next": "^9.0.10",
     "react-motion": "^0.5.2",
     "react-responsive": "^8.0.3",
     "react-syntax-highlighter": "^12.2.1",
@@ -37,8 +37,8 @@
     "suomifi-ui-components": "0.11.0"
   },
   "resolutions": {
-    "@wapps/gatsby-plugin-i18next/i18next": "^15.0.6",
-    "@wapps/gatsby-plugin-i18next/react-i18next": "^8.4.0"
+    "@wapps/gatsby-plugin-i18next/i18next": "^19.3.4",
+    "@wapps/gatsby-plugin-i18next/react-i18next": "^9.0.10"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^2.2.2",
     "gatsby-transformer-code": "^0.1.0",
-    "gatsby-transformer-sharp": "^2.4.2",
+    "gatsby-transformer-sharp": "^2.4.4",
     "i18next": "^19.3.4",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gatsby-source-filesystem": "^2.2.2",
     "gatsby-transformer-code": "^0.1.0",
     "gatsby-transformer-sharp": "^2.4.2",
-    "i18next": "^15.0.6",
+    "i18next": "^19.3.4",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^16.13.1",
     "react-element-to-jsx-string": "^14.3.1",
     "react-helmet": "^5.2.1",
-    "react-i18next": "^10.13.2",
+    "react-i18next": "^11.3.4",
     "react-motion": "^0.5.2",
     "react-responsive": "^8.0.3",
     "react-syntax-highlighter": "^12.2.1",
@@ -38,7 +38,7 @@
   },
   "resolutions": {
     "@wapps/gatsby-plugin-i18next/i18next": "^19.3.4",
-    "@wapps/gatsby-plugin-i18next/react-i18next": "^10.13.2"
+    "@wapps/gatsby-plugin-i18next/react-i18next": "^11.3.4"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^16.13.1",
     "react-element-to-jsx-string": "^14.3.1",
     "react-helmet": "^5.2.1",
-    "react-i18next": "^9.0.10",
+    "react-i18next": "^10.13.2",
     "react-motion": "^0.5.2",
     "react-responsive": "^8.0.3",
     "react-syntax-highlighter": "^12.2.1",
@@ -38,7 +38,7 @@
   },
   "resolutions": {
     "@wapps/gatsby-plugin-i18next/i18next": "^19.3.4",
-    "@wapps/gatsby-plugin-i18next/react-i18next": "^9.0.10"
+    "@wapps/gatsby-plugin-i18next/react-i18next": "^10.13.2"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -68,11 +68,9 @@
     ]
   },
   "devDependencies": {
-    "@types/i18next": "^13.0.0",
     "@types/react": "^16.9.32",
     "@types/react-dom": "^16.9.6",
     "@types/react-helmet": "^5.0.15",
-    "@types/react-i18next": "^8.1.0",
     "@types/react-responsive": "^8.0.2",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@svgr/webpack": "^5.3.1",
     "@wapps/gatsby-plugin-i18next": "^1.1.6",
     "babel-plugin-styled-components": "^1.10.7",
-    "gatsby": "^2.20.13",
+    "gatsby": "^2.20.14",
     "gatsby-image": "^2.3.2",
     "gatsby-plugin-manifest": "^2.3.3",
     "gatsby-plugin-module-resolver": "^1.0.3",
@@ -22,7 +22,7 @@
     "gatsby-source-filesystem": "^2.2.2",
     "gatsby-transformer-code": "^0.1.0",
     "gatsby-transformer-sharp": "^2.4.4",
-    "i18next": "^19.3.4",
+    "i18next": "^19.4.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -37,7 +37,7 @@
     "suomifi-ui-components": "0.11.0"
   },
   "resolutions": {
-    "@wapps/gatsby-plugin-i18next/i18next": "^19.3.4",
+    "@wapps/gatsby-plugin-i18next/i18next": "^19.4.0",
     "@wapps/gatsby-plugin-i18next/react-i18next": "^11.3.4"
   },
   "license": "MIT",
@@ -68,7 +68,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react": "^16.9.32",
+    "@types/react": "^16.9.33",
     "@types/react-dom": "^16.9.6",
     "@types/react-helmet": "^5.0.15",
     "@types/react-responsive": "^8.0.2",

--- a/src/components/ComponentDescription.tsx
+++ b/src/components/ComponentDescription.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { Expander, suomifiDesignTokens } from 'suomifi-ui-components';
 import ComponentCode from 'components/ComponentCode';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
@@ -22,7 +22,7 @@ const ComponentDescription = ({
   filterProps,
   children,
 }: Props): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <div
         style={{
@@ -62,7 +62,7 @@ const ComponentDescription = ({
         )}
       </div>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 interface Props {

--- a/src/components/ContentBoxes.tsx
+++ b/src/components/ContentBoxes.tsx
@@ -102,7 +102,7 @@ const ContentBoxes = ({
   </section>
 );
 
-interface Props {
+export interface Props {
   wrapAll?: boolean;
   hasFrame?: boolean;
   mainTitle: string;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import { Text, Paragraph } from 'components/ResponsiveComponents';
@@ -126,7 +126,7 @@ const AllContent = ({
   center?: boolean;
   wrapAll?: boolean;
 }): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <>
         <Content
@@ -181,7 +181,7 @@ const AllContent = ({
         />
       </>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 const Footer = (): JSX.Element => (

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Language } from '@wapps/gatsby-plugin-i18next';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import {
   LanguageMenu,
   LanguageMenuItem,
@@ -16,7 +16,7 @@ const MenuSwitcher = ({
   lng,
   availableLngs,
 }: Props): JSX.Element => (
-  <NamespacesConsumer ns={['language']}>
+  <Translation ns={['language']}>
     {(t) => (
       <LanguageMenu name={t(`${lng}.short`)} aria-label={t('menu.label')}>
         {availableLngs.map((value) => (
@@ -30,7 +30,7 @@ const MenuSwitcher = ({
         ))}
       </LanguageMenu>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 const ListSwitcher = ({
@@ -38,7 +38,7 @@ const ListSwitcher = ({
   lng,
   availableLngs,
 }: Props): JSX.Element => (
-  <NamespacesConsumer ns={['language']}>
+  <Translation ns={['language']}>
     {(t) => (
       <ul
         aria-label={t('menu.label')}
@@ -65,7 +65,7 @@ const ListSwitcher = ({
         ))}
       </ul>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 interface Props {

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { Link as GatsbyLink } from '@wapps/gatsby-plugin-i18next';
 import {
   Link as SuomifiLink,
@@ -40,7 +40,7 @@ const Link = ({ icon, text, title, url, style }: Props): JSX.Element => {
   );
 
   return (
-    <NamespacesConsumer>
+    <Translation>
       {(t) =>
         url.startsWith('/') ? (
           <CustomLink
@@ -63,7 +63,7 @@ const Link = ({ icon, text, title, url, style }: Props): JSX.Element => {
           </CustomLink>
         )
       }
-    </NamespacesConsumer>
+    </Translation>
   );
 };
 

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Icon, suomifiDesignTokens, Button } from 'suomifi-ui-components';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 
 import MainMenuItem from 'components/MainMenuItem';
 import { MainNavData } from 'components/MainNavData';
@@ -30,7 +30,7 @@ class MainMenu extends Component<Props, State> {
     const { mainNavData } = this.props;
 
     return (
-      <NamespacesConsumer>
+      <Translation>
         {(t) => (
           <div style={{ position: 'relative' }}>
             <Button
@@ -88,7 +88,7 @@ class MainMenu extends Component<Props, State> {
             )}
           </div>
         )}
-      </NamespacesConsumer>
+      </Translation>
     );
   }
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import NavItem from 'components/NavItem';
 import { MainNavData } from 'components/MainNavData';
 
 const Navigation = ({ mainNavData }: Props): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <nav
         aria-label={t('common:navigation.main')}
@@ -44,7 +44,7 @@ const Navigation = ({ mainNavData }: Props): JSX.Element => (
         </ul>
       </nav>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 interface Props {

--- a/src/components/NotificationBox.tsx
+++ b/src/components/NotificationBox.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react';
 import { suomifiDesignTokens, Icon } from 'suomifi-ui-components';
 import { Text } from 'components/ResponsiveComponents';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 
 interface Props {
   style?: CSSProperties;
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const NotificationBox = ({ style, notificationText }: Props): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <div
         style={{
@@ -38,7 +38,7 @@ const NotificationBox = ({ style, notificationText }: Props): JSX.Element => (
         </Text.bold>
       </div>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 NotificationBox.displayName = 'div';

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -44,7 +44,7 @@ const Section = ({
   </section>
 );
 
-interface Props {
+export interface Props {
   mainTitle?: string;
   title?: string;
   paragraphs: ParagraphProps[];

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import LanguageSwitcher from 'components/LanguageSwitcher';
@@ -10,7 +10,7 @@ import mainNavData from 'config/mainnav';
 import Link from 'components/Link';
 
 const Header = (): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <header
         style={{
@@ -72,7 +72,7 @@ const Header = (): JSX.Element => (
         </div>
       </header>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default Header;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Header from 'components/header';
@@ -15,7 +15,7 @@ import '@csstools/normalize.css';
 import './layout.css';
 
 const BypassLinks = ({ hasSideNav }: { hasSideNav: boolean }): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <>
         <BypassLink to="#main">{t('common:to.main.content')}</BypassLink>
@@ -24,7 +24,7 @@ const BypassLinks = ({ hasSideNav }: { hasSideNav: boolean }): JSX.Element => (
         )}
       </>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 const Layout = ({
@@ -32,7 +32,7 @@ const Layout = ({
   hasFrame = true,
   children,
 }: Props): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t) => (
       <div
         style={{
@@ -57,7 +57,7 @@ const Layout = ({
         <Footer />
       </div>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 interface Props {

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 
 const SEO = ({
   title,
@@ -8,7 +8,7 @@ const SEO = ({
   meta = [],
   keywords = [],
 }: Props): JSX.Element => (
-  <NamespacesConsumer>
+  <Translation>
     {(t, { i18n }) => {
       const metaDescription = description || t('common:site.description');
       const lang = i18n.language;
@@ -36,7 +36,7 @@ const SEO = ({
         />
       );
     }}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 interface Props {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -9,7 +9,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Link from 'components/Link';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['404']}>
+  <Translation ns={['404']}>
     {(t) => (
       <Layout>
         <SEO title={t('title')} />
@@ -22,7 +22,7 @@ const Page = (): JSX.Element => (
         </div>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/accessibility-statement.tsx
+++ b/src/pages/accessibility-statement.tsx
@@ -6,8 +6,8 @@ import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
-import Section from 'components/Section';
 import { Heading } from 'components/ResponsiveComponents';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = (): JSX.Element => (
   <Translation ns={['accessibility-statement']}>
@@ -16,7 +16,7 @@ const Page = (): JSX.Element => (
         <div style={{ padding: `0 ${suomifiDesignTokens.spacing.xl}` }}>
           <SEO title={t('title')} />
           <Heading variant="h1">{t('title')}</Heading>
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}
@@ -29,7 +29,6 @@ const Page = (): JSX.Element => (
     )}
   </Translation>
 );
-
 export default withI18next()(Page);
 
 export const query = graphql`

--- a/src/pages/accessibility-statement.tsx
+++ b/src/pages/accessibility-statement.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
@@ -10,7 +10,7 @@ import Section from 'components/Section';
 import { Heading } from 'components/ResponsiveComponents';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['accessibility-statement']}>
+  <Translation ns={['accessibility-statement']}>
     {(t) => (
       <Layout>
         <div style={{ padding: `0 ${suomifiDesignTokens.spacing.xl}` }}>
@@ -27,7 +27,7 @@ const Page = (): JSX.Element => (
         </div>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/block.tsx
+++ b/src/pages/components/block.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -16,7 +16,7 @@ import NotificationBox from 'components/NotificationBox';
 
 const Page: React.FC = (): React.ReactElement => {
   return (
-    <NamespacesConsumer ns={['block']}>
+    <Translation ns={['block']}>
       {(t) => (
         <Layout sideNavData={sideNavData(t)}>
           <SEO title={t('title')} />
@@ -47,7 +47,7 @@ const Page: React.FC = (): React.ReactElement => {
           ))}
         </Layout>
       )}
-    </NamespacesConsumer>
+    </Translation>
   );
 };
 

--- a/src/pages/components/block.tsx
+++ b/src/pages/components/block.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
@@ -37,7 +37,7 @@ const Page: React.FC = (): React.ReactElement => {
 
           <NoteBox title={t('note.title')} items={t('note.items')} />
 
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}

--- a/src/pages/components/breadcrumb.tsx
+++ b/src/pages/components/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -14,7 +14,7 @@ import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['breadcrumb']}>
+  <Translation ns={['breadcrumb']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -51,7 +51,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/breadcrumb.tsx
+++ b/src/pages/components/breadcrumb.tsx
@@ -9,7 +9,7 @@ import { Breadcrumb } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -41,7 +41,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -10,7 +10,7 @@ import { Button } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import MobileDevice from 'components/MobileDevice';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
@@ -99,7 +99,7 @@ const Page = (): JSX.Element => {
 
           <NoteBox title={t('note.title')} items={t('note.items')} />
 
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
@@ -87,7 +87,7 @@ const getExampleComp = (
 
 const Page = (): JSX.Element => {
   return (
-    <NamespacesConsumer ns={['button']}>
+    <Translation ns={['button']}>
       {(t) => (
         <Layout sideNavData={sideNavData(t)}>
           <SEO title={t('title')} />
@@ -250,7 +250,7 @@ const Page = (): JSX.Element => {
           </ComponentDescription>
         </Layout>
       )}
-    </NamespacesConsumer>
+    </Translation>
   );
 };
 

--- a/src/pages/components/dropdown.tsx
+++ b/src/pages/components/dropdown.tsx
@@ -9,7 +9,7 @@ import { Dropdown } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -45,7 +45,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/components/dropdown.tsx
+++ b/src/pages/components/dropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -14,7 +14,7 @@ import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['dropdown']}>
+  <Translation ns={['dropdown']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -55,7 +55,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/expander.tsx
+++ b/src/pages/components/expander.tsx
@@ -10,7 +10,7 @@ import { Expander } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -27,7 +27,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/components/expander.tsx
+++ b/src/pages/components/expander.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
@@ -15,7 +15,7 @@ import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['expander']}>
+  <Translation ns={['expander']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -94,7 +94,7 @@ const Page = (): JSX.Element => (
         </ComponentDescription>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/heading.tsx
+++ b/src/pages/components/heading.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
@@ -27,7 +27,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/components/heading.tsx
+++ b/src/pages/components/heading.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -15,7 +15,7 @@ import { Heading as SuomifiHeading } from 'components/ExampleComponents';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['heading']}>
+  <Translation ns={['heading']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -125,7 +125,7 @@ const Page = (): JSX.Element => (
         </ComponentDescription>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/icon.tsx
+++ b/src/pages/components/icon.tsx
@@ -8,7 +8,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import NoteBox from 'components/NoteBox';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Paragraph, Text } from 'components/ResponsiveComponents';
@@ -54,7 +54,7 @@ const Page: React.FC = (): React.ReactElement => {
 
           <NoteBox title={t('note.title')} items={t('note.items')} />
 
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}

--- a/src/pages/components/icon.tsx
+++ b/src/pages/components/icon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -40,7 +40,7 @@ StaticIcon.displayName = 'StaticIcon';
 
 const Page: React.FC = (): React.ReactElement => {
   return (
-    <NamespacesConsumer ns={['icon']}>
+    <Translation ns={['icon']}>
       {(t) => (
         <Layout sideNavData={sideNavData(t)}>
           <SEO title={t('title')} />
@@ -202,7 +202,7 @@ const Page: React.FC = (): React.ReactElement => {
           </Link>
         </Layout>
       )}
-    </NamespacesConsumer>
+    </Translation>
   );
 };
 

--- a/src/pages/components/index.tsx
+++ b/src/pages/components/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -15,7 +15,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Section from 'components/Section';
 
 const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
-  <NamespacesConsumer ns={['components']}>
+  <Translation ns={['components']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('info.title')} />
@@ -59,7 +59,7 @@ const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
         </ComponentDescription>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/index.tsx
+++ b/src/pages/components/index.tsx
@@ -12,7 +12,7 @@ import { Example } from 'examples/components';
 import { Example as ExampleAdvanced } from 'examples/componentsAdvanced';
 import { getExample, CodeExampleData } from 'components/CodeExampleUtil';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
   <Translation ns={['components']}>
@@ -25,7 +25,7 @@ const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
           <Text.lead>{t('intro')}</Text.lead>
         </Paragraph.lead>
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/components/languagemenu.tsx
+++ b/src/pages/components/languagemenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 import i18next from 'i18next';
 import Layout from 'components/layout';
@@ -18,7 +18,7 @@ const Page = (): JSX.Element => {
     i18next.t('languagemenu:example.menuitem1short'),
   );
   const pageContent = (
-    <NamespacesConsumer ns={['languagemenu']}>
+    <Translation ns={['languagemenu']}>
       {(t) => (
         <Layout sideNavData={sideNavData(t)}>
           <SEO title={t('title')} />
@@ -65,7 +65,7 @@ const Page = (): JSX.Element => {
           ))}
         </Layout>
       )}
-    </NamespacesConsumer>
+    </Translation>
   );
   return pageContent;
 };

--- a/src/pages/components/languagemenu.tsx
+++ b/src/pages/components/languagemenu.tsx
@@ -9,7 +9,7 @@ import { LanguageMenu, LanguageMenuItem } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -55,7 +55,7 @@ const Page = (): JSX.Element => {
 
           <NoteBox title={t('note.title')} items={t('note.items')} />
 
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}

--- a/src/pages/components/link.tsx
+++ b/src/pages/components/link.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -14,7 +14,7 @@ import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['link']}>
+  <Translation ns={['link']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -63,7 +63,7 @@ const Page = (): JSX.Element => (
         </ComponentDescription>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/link.tsx
+++ b/src/pages/components/link.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import { Link as ExampleLink } from 'components/ExampleComponents';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
@@ -26,7 +26,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/components/searchinput.tsx
+++ b/src/pages/components/searchinput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -15,7 +15,7 @@ import NotificationBox from 'components/NotificationBox';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['searchinput']}>
+  <Translation ns={['searchinput']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -37,7 +37,7 @@ const Page = (): JSX.Element => (
         <NoteBox title={t('note.title')} items={t('note.items')} />
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/text.tsx
+++ b/src/pages/components/text.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -42,7 +42,7 @@ const ExampleBlock = ({
 
 const Page: React.FC = (): React.ReactElement => {
   return (
-    <NamespacesConsumer ns={['text']}>
+    <Translation ns={['text']}>
       {(t) => (
         <Layout sideNavData={sideNavData(t)}>
           <SEO title={t('title')} />
@@ -80,7 +80,7 @@ const Page: React.FC = (): React.ReactElement => {
           </ExampleBlock>
         </Layout>
       )}
-    </NamespacesConsumer>
+    </Translation>
   );
 };
 

--- a/src/pages/components/text.tsx
+++ b/src/pages/components/text.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Paragraph } from 'components/ResponsiveComponents';
 import { Text } from 'components/ExampleComponents';
@@ -52,7 +52,7 @@ const Page: React.FC = (): React.ReactElement => {
             <Text.lead>{t('intro')}</Text.lead>
           </Paragraph.lead>
 
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}

--- a/src/pages/components/textinput.tsx
+++ b/src/pages/components/textinput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -15,7 +15,7 @@ import NotificationBox from 'components/NotificationBox';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['textinput']}>
+  <Translation ns={['textinput']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -74,7 +74,7 @@ const Page = (): JSX.Element => (
         </ComponentDescription>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/components/toggle.tsx
+++ b/src/pages/components/toggle.tsx
@@ -9,7 +9,7 @@ import { Toggle } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -52,7 +52,7 @@ const Page: React.FC = (): React.ReactElement => {
           </ComponentDescription>
           <NoteBox title={t('note.title')} items={t('note.items')} />
 
-          {t('sections').map((section, index) => (
+          {t<SectionProps[]>('sections').map((section, index) => (
             <Section
               key={index}
               mainTitle={section.title}

--- a/src/pages/components/toggle.tsx
+++ b/src/pages/components/toggle.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -26,7 +26,7 @@ const Page: React.FC = (): React.ReactElement => {
   };
 
   return (
-    <NamespacesConsumer ns={['toggle']}>
+    <Translation ns={['toggle']}>
       {(t) => (
         <Layout sideNavData={sideNavData(t)}>
           <SEO title={t('title')} />
@@ -62,7 +62,7 @@ const Page: React.FC = (): React.ReactElement => {
           ))}
         </Layout>
       )}
-    </NamespacesConsumer>
+    </Translation>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -9,7 +9,7 @@ import ContentBoxes from 'components/ContentBoxes';
 import Hero from 'components/Hero';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['home']}>
+  <Translation ns={['home']}>
     {(t) => (
       <Layout hasFrame={false}>
         <SEO title={t('title')} />
@@ -26,7 +26,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,9 @@ import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
-import ContentBoxes from 'components/ContentBoxes';
+import ContentBoxes, {
+  Props as ContentBoxProps,
+} from 'components/ContentBoxes';
 import Hero from 'components/Hero';
 
 const Page = (): JSX.Element => (
@@ -16,7 +18,7 @@ const Page = (): JSX.Element => (
 
         <Hero title={t('intro.title')} description={t('intro.description')} />
 
-        {t('sections').map((section, index) => (
+        {t<ContentBoxProps[]>('sections').map((section, index) => (
           <ContentBoxes
             key={index}
             wrapAll

--- a/src/pages/info/accessibility.tsx
+++ b/src/pages/info/accessibility.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/info';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = (): JSX.Element => (
   <Translation ns={['accessibility']}>
@@ -20,7 +20,7 @@ const Page = (): JSX.Element => (
           <Text.lead>{t('intro')}</Text.lead>
         </Paragraph.lead>
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/info/accessibility.tsx
+++ b/src/pages/info/accessibility.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -10,7 +10,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Section from 'components/Section';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['accessibility']}>
+  <Translation ns={['accessibility']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -30,7 +30,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/info/designers.tsx
+++ b/src/pages/info/designers.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/info';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = (): JSX.Element => (
   <Translation ns={['designers']}>
@@ -20,7 +20,7 @@ const Page = (): JSX.Element => (
           <Text.lead>{t('intro')}</Text.lead>
         </Paragraph.lead>
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/info/designers.tsx
+++ b/src/pages/info/designers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -10,7 +10,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Section from 'components/Section';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['designers']}>
+  <Translation ns={['designers']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -31,7 +31,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/info/developers.tsx
+++ b/src/pages/info/developers.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/info';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = (): JSX.Element => (
   <Translation ns={['developers']}>
@@ -20,7 +20,7 @@ const Page = (): JSX.Element => (
           <Text.lead>{t('intro')}</Text.lead>
         </Paragraph.lead>
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/info/developers.tsx
+++ b/src/pages/info/developers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -10,7 +10,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Section from 'components/Section';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['developers']}>
+  <Translation ns={['developers']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -30,7 +30,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/info/index.tsx
+++ b/src/pages/info/index.tsx
@@ -7,7 +7,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/info';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = (): JSX.Element => (
   <Translation ns={['info']}>
@@ -20,7 +20,7 @@ const Page = (): JSX.Element => (
           <Text.lead>{t('intro')}</Text.lead>
         </Paragraph.lead>
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/info/index.tsx
+++ b/src/pages/info/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -10,7 +10,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Section from 'components/Section';
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['info']}>
+  <Translation ns={['info']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('info.title')} />
@@ -30,7 +30,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/styles/colors.tsx
+++ b/src/pages/styles/colors.tsx
@@ -10,7 +10,7 @@ import SEO from 'components/seo';
 import ComponentDescription from 'components/ComponentDescription';
 import sideNavData from 'config/sidenav/styles';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
@@ -149,7 +149,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/styles/colors.tsx
+++ b/src/pages/styles/colors.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 import { getLuminance } from 'polished';
@@ -137,7 +137,7 @@ const getExampleColor = (
 );
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['colors']}>
+  <Translation ns={['colors']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -188,7 +188,7 @@ const Page = (): JSX.Element => (
         ))}
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/styles/icons.tsx
+++ b/src/pages/styles/icons.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react';
 import { graphql } from 'gatsby';
 import styled from 'styled-components';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 import { baseIcons, illustrativeIcons, doctypeIcons } from 'suomifi-icons';
 import {
@@ -79,7 +79,7 @@ const getExampleIcon = (
 );
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['icons', 'static-icons']}>
+  <Translation ns={['icons', 'static-icons']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -133,7 +133,7 @@ const Page = (): JSX.Element => (
         />
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/styles/index.tsx
+++ b/src/pages/styles/index.tsx
@@ -11,7 +11,7 @@ import ComponentExample from 'components/ComponentExample';
 import { Example } from 'examples/styles';
 import { getExample, CodeExampleData } from 'components/CodeExampleUtil';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 
 const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
   <Translation ns={['styles']}>
@@ -24,7 +24,7 @@ const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
           <Text.lead>{t('intro')}</Text.lead>
         </Paragraph.lead>
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/src/pages/styles/index.tsx
+++ b/src/pages/styles/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import Layout from 'components/layout';
@@ -14,7 +14,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import Section from 'components/Section';
 
 const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
-  <NamespacesConsumer ns={['styles']}>
+  <Translation ns={['styles']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('info.title')} />
@@ -46,7 +46,7 @@ const Page = ({ data }: { data: CodeExampleData }): JSX.Element => (
         </ComponentDescription>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/styles/typography.tsx
+++ b/src/pages/styles/typography.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { NamespacesConsumer } from 'react-i18next';
+import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
 
 import { suomifiDesignTokens } from 'suomifi-ui-components';
@@ -46,7 +46,7 @@ const ExampleBlock = ({
 );
 
 const Page = (): JSX.Element => (
-  <NamespacesConsumer ns={['typography']}>
+  <Translation ns={['typography']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
@@ -208,7 +208,7 @@ const Page = (): JSX.Element => (
         </ExampleBlock>
       </Layout>
     )}
-  </NamespacesConsumer>
+  </Translation>
 );
 
 export default withI18next()(Page);

--- a/src/pages/styles/typography.tsx
+++ b/src/pages/styles/typography.tsx
@@ -9,7 +9,7 @@ import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/styles';
 import NoteBox from 'components/NoteBox';
-import Section from 'components/Section';
+import Section, { Props as SectionProps } from 'components/Section';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
@@ -58,7 +58,7 @@ const Page = (): JSX.Element => (
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
-        {t('sections').map((section, index) => (
+        {t<SectionProps[]>('sections').map((section, index) => (
           <Section
             key={index}
             mainTitle={section.title}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7736,7 +7736,7 @@ hyphenate-style-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-i18next@*:
+i18next@*, i18next@^19.3.4:
   version "19.3.4"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.3.4.tgz#512de50ee6075df825c646e1ce646a104f0938c9"
   integrity sha512-ef7AxxutzdhBsBNugE9jgqsbwesG1muJOtZ9ZrPARPs/jXegViTp4+8JCeMp8BAyTIo1Zn0giqc8+2UpqFjU0w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,11 +2338,6 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -3965,11 +3960,6 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
   integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-js@^2.4.0, core-js@^2.6.11, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -4061,14 +4051,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-context@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
-  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 create-react-context@0.3.0:
   version "0.3.0"
@@ -5007,13 +4989,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -5875,19 +5850,6 @@ faye-websocket@~0.11.0, faye-websocket@~0.11.1:
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
-
-fbjs@^0.8.0:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 fd-slicer@~1.1.0:
   version "1.1.0"
@@ -7509,10 +7471,10 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz#fba3e7df0210eb9447757ca1a7cb607162f0a364"
-  integrity sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==
+hoist-non-react-statics@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
   dependencies:
     react-is "^16.3.2"
 
@@ -7736,21 +7698,14 @@ hyphenate-style-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-i18next@*, i18next@^19.3.4:
+i18next@*, i18next@^15.1.3, i18next@^19.3.4:
   version "19.3.4"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.3.4.tgz#512de50ee6075df825c646e1ce646a104f0938c9"
   integrity sha512-ef7AxxutzdhBsBNugE9jgqsbwesG1muJOtZ9ZrPARPs/jXegViTp4+8JCeMp8BAyTIo1Zn0giqc8+2UpqFjU0w==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-i18next@^15.0.6, i18next@^15.1.3:
-  version "15.1.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-15.1.3.tgz#f1984cbee0e3cb00cff9008b037264289ce8840a"
-  integrity sha512-hN2DZLoRSY2h/RYeNqth5XxV4N1ekKGSJDCGhFmmuXkOCAfK5CkUG4VBv9OBXrvf93xApv0KKBVrb0zJP31EKg==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8626,7 +8581,7 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^1.1.0"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -8750,14 +8705,6 @@ isobject@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -10153,14 +10100,6 @@ node-fetch@2.6.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -11974,13 +11913,6 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"
@@ -12357,14 +12289,13 @@ react-i18next@*:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
-react-i18next@^10.11.0, react-i18next@^8.4.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-8.4.0.tgz#e9f0c5b9938b155eaa6051360614719c08cae72f"
-  integrity sha512-zIO/bc1L0UUGdaws2y40cTiSQHuQud5e9SSodYM6MTzhJTI3iayxCCdgvotblOLM4taOD77Ct2/fUbheQIhyeg==
+react-i18next@^10.11.0, react-i18next@^9.0.10:
+  version "9.0.10"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-9.0.10.tgz#ba596b98e8dd06dbb805cf720147459ad55a3ada"
+  integrity sha512-xpeCWNut7ylQLs3Qqyo7dT13kgZbML1CdftbdnswLCv0RbRT16bRP16ma59iLe1KHIbn92VJo0Q8LSKYoXVNvg==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    create-react-context "0.2.3"
-    hoist-non-react-statics "3.0.1"
+    "@babel/runtime" "^7.3.1"
+    hoist-non-react-statics "3.2.1"
     html-parse-stringify2 "2.0.1"
 
 react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
@@ -13323,7 +13254,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -14901,11 +14832,6 @@ typescript@^3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
-ua-parser-js@^0.7.18:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
-
 unbzip2-stream@^1.0.9:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz#097ca7b18b5b71e6c8bc8e514a0f1884a12d6eb1"
@@ -15535,11 +15461,6 @@ whatwg-fetch@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6605,7 +6605,7 @@ gatsby-transformer-code@^0.1.0:
   resolved "https://registry.yarnpkg.com/gatsby-transformer-code/-/gatsby-transformer-code-0.1.0.tgz#8cef659d17bd5148f52846292f440d10782919df"
   integrity sha512-20vp/+z2oyTbvaP0fxoijOHtRtIpiUQK84ArkV81Ml+zBeR2nEt2Jr8eWp/oo4bomh+bzG2jSG6695jkeTwVtQ==
 
-gatsby-transformer-sharp@^2.4.2:
+gatsby-transformer-sharp@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.4.4.tgz#f43410bca43d8cdfee8e3f159501592569ff2a3d"
   integrity sha512-LqaCvmpHBFiMvTmQjlogFn/3jgGOiWQxJsR/wclXlvgMAV1ffxiR6zr5OKwivuRueQ4gwn33adjCeLp3/iQtAA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7471,13 +7471,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
-  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
-  dependencies:
-    react-is "^16.3.2"
-
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -12289,16 +12282,15 @@ react-i18next@*:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
-react-i18next@^10.11.0, react-i18next@^9.0.10:
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-9.0.10.tgz#ba596b98e8dd06dbb805cf720147459ad55a3ada"
-  integrity sha512-xpeCWNut7ylQLs3Qqyo7dT13kgZbML1CdftbdnswLCv0RbRT16bRP16ma59iLe1KHIbn92VJo0Q8LSKYoXVNvg==
+react-i18next@^10.11.0, react-i18next@^10.13.2:
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-10.13.2.tgz#2943705fa751d366fc95b3755520ebe6eeed2408"
+  integrity sha512-DGoauWUdPEv/+PLa03nN+wlW31XrGmQJz+zIyOA+tRTIwlRaNgeM62nGP1WG3g7fJrphMZUwPcAQqNv6XBYM4w==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    hoist-non-react-statics "3.2.1"
     html-parse-stringify2 "2.0.1"
 
-react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12260,10 +12260,10 @@ react-hot-loader@^4.12.20:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
-react-i18next@^10.11.0, react-i18next@^10.13.2:
-  version "10.13.2"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-10.13.2.tgz#2943705fa751d366fc95b3755520ebe6eeed2408"
-  integrity sha512-DGoauWUdPEv/+PLa03nN+wlW31XrGmQJz+zIyOA+tRTIwlRaNgeM62nGP1WG3g7fJrphMZUwPcAQqNv6XBYM4w==
+react-i18next@^10.11.0, react-i18next@^11.3.4:
+  version "11.3.4"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.3.4.tgz#355df5fe5133e5e30302d166f529678100ffc968"
+  integrity sha512-IRZMD7PAM3C+fJNzRbyLNi1ZD0kc3Z3obBspJjEl+9H+ME41PhVor3BpdIqv/Rm7lUoGhMjmpu42J45ooJ61KA==
   dependencies:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,13 +1622,6 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
   integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
 
-"@types/i18next@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@types/i18next/-/i18next-13.0.0.tgz#403ef338add0104e74d9759f1b39217e7c5d4084"
-  integrity sha512-gp/SIShAuf4WOqi8ey0nuI7qfWaVpMNCcs/xLygrh/QTQIXmlDC1E0TtVejweNW+7SGDY7g0lyxyKZIJuCKIJw==
-  dependencies:
-    i18next "*"
-
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -1707,13 +1700,6 @@
   integrity sha512-CCjqvecDJTXRrHG8aTc2YECcQCl26za/q+NaBRvy/wtm0Uh38koM2dpv2bG1xJV4ckz3t1lm2/5KU6nt2s9BWg==
   dependencies:
     "@types/react" "*"
-
-"@types/react-i18next@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@types/react-i18next/-/react-i18next-8.1.0.tgz#5faacbfe7dc0f24729c1df6914610bfe861a50de"
-  integrity sha512-d4xhcjX5b3roNMObRNMfb1HinHQlQLPo8xlDj60dnHeeAw2bBymR2cy/l1giJpHzo/ZFgSvgVUvIWr4kCrenCg==
-  dependencies:
-    react-i18next "*"
 
 "@types/react-responsive@^8.0.2":
   version "8.0.2"
@@ -7691,7 +7677,7 @@ hyphenate-style-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-i18next@*, i18next@^15.1.3, i18next@^19.3.4:
+i18next@^15.1.3, i18next@^19.3.4:
   version "19.3.4"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.3.4.tgz#512de50ee6075df825c646e1ce646a104f0938c9"
   integrity sha512-ef7AxxutzdhBsBNugE9jgqsbwesG1muJOtZ9ZrPARPs/jXegViTp4+8JCeMp8BAyTIo1Zn0giqc8+2UpqFjU0w==
@@ -12273,14 +12259,6 @@ react-hot-loader@^4.12.20:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.1.0"
     source-map "^0.7.3"
-
-react-i18next@*:
-  version "11.3.4"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.3.4.tgz#355df5fe5133e5e30302d166f529678100ffc968"
-  integrity sha512-IRZMD7PAM3C+fJNzRbyLNi1ZD0kc3Z3obBspJjEl+9H+ME41PhVor3BpdIqv/Rm7lUoGhMjmpu42J45ooJ61KA==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    html-parse-stringify2 "2.0.1"
 
 react-i18next@^10.11.0, react-i18next@^10.13.2:
   version "10.13.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,9 +1650,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "13.11.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.0.tgz#390ea202539c61c8fa6ba4428b57e05bc36dc47b"
-  integrity sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
+  integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
 
 "@types/node@^8.5.7":
   version "8.10.59"
@@ -1708,10 +1708,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.32":
-  version "16.9.32"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.32.tgz#f6368625b224604148d1ddf5920e4fefbd98d383"
-  integrity sha512-fmejdp0CTH00mOJmxUPPbWCEBWPvRIL4m8r0qD+BSDUqmutPyGQCHifzMpMzdvZwROdEdL78IuZItntFWgPXHQ==
+"@types/react@*", "@types/react@^16.9.33":
+  version "16.9.33"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.33.tgz#a5274520f0d28cbbb73c8652ddd48646fd4bcae5"
+  integrity sha512-ovgoy7p9999HDzwv8Sewhl8GJjn/r0GRsFrM9UMwp1uodh0kQ0pwIHLQ6LNfqGSyjNzJ8II/HIg0BL7Yn/B9yA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -2446,9 +2446,9 @@ autoprefixer@^9.7.4, autoprefixer@^9.7.5:
     postcss-value-parser "^4.0.3"
 
 aws-sdk@^2.382.0:
-  version "2.655.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.655.0.tgz#e95da28e66f02a4bfc0eab46731e2140364b3ea2"
-  integrity sha512-ywXbaPSwQ+YGo7ZGx7KnmoMO0O7fiEL+rttZIsx6AymLZUohfZ7GlRjG8z93jHa+22qWPMEJ+5UC05/PXWbf7Q==
+  version "2.656.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.656.0.tgz#0d74664ddbf30701073be9f9913ee7266afef3b4"
+  integrity sha512-UzqDvvt6i7gpuzEdK0GT/JOfBJcsCPranzZWdQ9HR4+5E0m5kf5gybZ6OX+UseIAE2/WND6Dv0aHgiI21AKenw==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -3273,9 +3273,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039:
-  version "1.0.30001039"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz#b3814a1c38ffeb23567f8323500c09526a577bbe"
-  integrity sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q==
+  version "1.0.30001040"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz#103fc8e6eb1d7397e95134cd0e996743353d58ea"
+  integrity sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -4923,9 +4923,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.390:
-  version "1.3.398"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz#4c01e29091bf39e578ac3f66c1f157d92fa5725d"
-  integrity sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w==
+  version "1.3.400"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.400.tgz#75af0e91c82d645e0e5175c906c69cb3f01d80ab"
+  integrity sha512-wZT7T37h2lMEv/fiWJBu6vJuuadAsqccr73n23GvxOBXgFYDIxR0JNfa5WVm8Ap2sBT4ZxCJk8Cp33BvtH/+OA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -6618,10 +6618,10 @@ gatsby-transformer-sharp@^2.4.4:
     semver "^5.7.1"
     sharp "^0.25.1"
 
-gatsby@^2.20.13:
-  version "2.20.13"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.20.13.tgz#e6b44e6e3ecf5f6a5c3e55f25f2097678a7db3a1"
-  integrity sha512-hPzmHSWhInIlY4Lg6hSrFlCxcITCsTs9QM5OhmmFtWDVY3fAr/MsVH1NVZJuY+rTFYtvk5hO284dOBMGcHtUww==
+gatsby@^2.20.14:
+  version "2.20.14"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.20.14.tgz#63c2637605c6b394fc4b8255f69ccf244b8df2b5"
+  integrity sha512-+5QAWaak1VaW+6dCa7dFlaZ8T+vM6z8k5zK4WpUTW6SLxyDgJLSOk4s3BkpElg9CK4tJvkueeQsCK+IRvTHFgw==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@babel/core" "^7.8.7"
@@ -7677,10 +7677,10 @@ hyphenate-style-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-i18next@^15.1.3, i18next@^19.3.4:
-  version "19.3.4"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.3.4.tgz#512de50ee6075df825c646e1ce646a104f0938c9"
-  integrity sha512-ef7AxxutzdhBsBNugE9jgqsbwesG1muJOtZ9ZrPARPs/jXegViTp4+8JCeMp8BAyTIo1Zn0giqc8+2UpqFjU0w==
+i18next@^15.1.3, i18next@^19.4.0:
+  version "19.4.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.4.0.tgz#492a03aac701d9efeeee86509d101a09d960b000"
+  integrity sha512-NvSz/Pb5KiLqhL+nqHu5SXNUtWDpHkVosVwD6PRSZWtBpVs6pXzqrRhyFdFvVivQcQheSxiHD3Oq1WKxoWy1ow==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
@@ -14511,9 +14511,9 @@ terser-webpack-plugin@^1.4.3:
     worker-farm "^1.7.0"
 
 terser@^4.1.2:
-  version "4.6.10"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.10.tgz#90f5bd069ff456ddbc9503b18e52f9c493d3b7c2"
-  integrity sha512-qbF/3UOo11Hggsbsqm2hPa6+L4w7bkr+09FNseEe8xrcVD3APGLFqE+Oz1ZKAxjYnFsj80rLOfgAtJ0LNJjtTA==
+  version "4.6.11"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.11.tgz#12ff99fdd62a26de2a82f508515407eb6ccd8a9f"
+  integrity sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
# Description

Update react-i18next, i18next dependencies as well as some other minor dependencies at the same time.

- Made the changes required by breaking changes of `react-i18next`
   - `NamespacesConsumer` was renamed to `Translation`
  - Typings added when mapping sections from the translation files


## Testing

Was tested locally running the DS-site

These were also successful
- `yarn build`
- `yarn validate`
