### PR TITLE
[Feature] Improve the Toggle's texts

### DIFF
--- a/locale/fi/toggle.json
+++ b/locale/fi/toggle.json
@@ -70,7 +70,7 @@
   ],
   "default.title": "",
   "default.description": "",
-  "toggle.label": "Oheisteksti",
-  "toggle.state.on": "{{name}} on kytketty päälle.",
-  "toggle.state.off": "{{name}} on kytketty pois päältä."
+  "toggle.label": "Esimerkkitoiminto",
+  "toggle.state.on": "{{name}} päällä.",
+  "toggle.state.off": "{{name}} pois päältä."
 }


### PR DESCRIPTION
# Description

Improved the Toggle component's texts
- When toggling the component -> screenreader reads the state
- Example component's label to more describing