### PR TITLE
[Fix] Skip link functionality

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -34,12 +34,14 @@ const Content = ({
   style?: CSSProperties;
 }): JSX.Element => (
   <main
+    tabIndex={-1}
     id="main"
     style={{
       margin: hasFrame
         ? `${suomifiDesignTokens.spacing.xl} ${suomifiDesignTokens.spacing.s}`
         : 0,
       ...style,
+      outline: 'none',
     }}
   >
     {children}


### PR DESCRIPTION
# Description

Skip link to main content doesn't work in reliable way; sometimes it works and sometimes it doesn't.
This is trying to get this working every time.

- main-content to have `tabIndex=-1`
- focus outline set to `none` for the main-content

## Details
> To make any target element focusable, add tabindex="-1" to the element. If the target is an a element, adding tabindex="-1" will remove it from the tab order.

Source: https://fae.disability.illinois.edu/rulesets/BYPASS_1/

Australian design system uses similar technic: https://designsystem.gov.au/components/skip-link/

## Testing

Tested to work on macOS Chrome & Safari