### PR TITLE
[Feature] CircleCi to use 'machine' instead of 'docker' as executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,7 @@ commands:
       - restore_cache:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-      - run: echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-      - run: sudo apt-get update
-      - run: sudo apt-get install yarn
+      - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
       - save_cache:
           key: yarn-packages-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   build-executor:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
 
 commands:
   build:
@@ -17,6 +17,8 @@ commands:
       - restore_cache:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
+      - run: curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+      - run: echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
       - run: sudo apt-get update
       - run: sudo apt-get install yarn
       - run: yarn install --frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ commands:
       - restore_cache:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
+      - run: sudo apt-get update
+      - run: sudo apt-get install yarn
       - run: yarn install --frozen-lockfile
       - save_cache:
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       # run tests!
-      - run: sudo apt-get update
-      - run: sudo apt-get install yarn
       - run: yarn validate
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ commands:
           paths:
             - ~/.cache/yarn
       # run tests!
+      - run: sudo apt-get update
+      - run: sudo apt-get install yarn
       - run: yarn validate
 
 jobs:
@@ -42,7 +44,7 @@ jobs:
             git config user.name "ci"
       - add_ssh_keys:
           fingerprints:
-            - "75:51:12:bc:d4:83:3b:7b:c0:1e:ac:61:14:bc:74:0d"
+            - '75:51:12:bc:d4:83:3b:7b:c0:1e:ac:61:14:bc:74:0d'
       - run: yarn deploy
 
   deploy-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ version: 2.1
 
 executors:
   build-executor:
-    docker:
-      - image: circleci/node:lts
+    machine:
+      image: ubuntu-1604:201903-01
 
 commands:
   build:


### PR DESCRIPTION
# Description

After the version 0.11.0 of suomifi-ui-components the Gatsby build progress time has increased noticeably.
Based on the [documentation](https://circleci.com/docs/2.0/executor-types/) this change could possible solve the current issue until the root cause for the increase is found and fixed, if possible.
