### PR TITLE
[Fix] Textarea and textinput content keys

### DIFF
--- a/locale/af/textarea.json
+++ b/locale/af/textarea.json
@@ -45,6 +45,7 @@
   "example.error.description": "example.error.description",
   "example.error.label": "example.error.label",
   "example.error.hintText": "example.error.hintText",
+  "example.error.placeholder": "example.error.placeholder",
   "example.error.statusText": "example.error.statusText",
   "example.disabled.title": "example.disabled.title",
   "example.disabled.description": "example.disabled.description",

--- a/locale/en/textarea.json
+++ b/locale/en/textarea.json
@@ -45,6 +45,7 @@
   "example.error.description": "",
   "example.error.label": "",
   "example.error.hintText": "",
+  "example.error.placeholder": "",
   "example.error.statusText": "",
   "example.disabled.title": "",
   "example.disabled.description": "",

--- a/locale/fi/textarea.json
+++ b/locale/fi/textarea.json
@@ -51,6 +51,7 @@
   "example.error.description": "Komponentille voidaan antaa ohje- ja notifikaatiotekstit. Ohjeteksti näytetään otsikon ja syötekentän välissä, ja notifikaatioteksti syötekentän alapuolella.",
   "example.error.label": "Perustelut",
   "example.error.hintText": "Perustele, miksi toimenpide tehdään ja millä tavalla toimenpide on päämiehen edun mukainen.",
+  "example.error.placeholder": "Kirjoita perustelut",
   "example.error.statusText": "Perustelut on pakollinen tieto",
   "example.disabled.title": "Estetty Tekstialue (Disabled Textarea)",
   "example.disabled.description": "Estetty tekstialue ei ole muokattavissa. Estetty -tila voidaan poistaa esimerkiksi, kun käyttäjä suorittaa toisen vaadittavan toimenpiteen.",

--- a/src/pages/components/textarea.tsx
+++ b/src/pages/components/textarea.tsx
@@ -30,9 +30,9 @@ const Page = (): JSX.Element => (
             style={{ marginBottom: suomifiDesignTokens.spacing.s }}
           >
             <Textarea
-              labelText={t('exampleRegular.label')}
-              hintText={t('exampleRegular.hintText')}
-              visualPlaceholder={t('exampleRegular.placeholder')}
+              labelText={t('example.regular.label')}
+              hintText={t('example.regular.hintText')}
+              visualPlaceholder={t('example.regular.placeholder')}
             />
           </ComponentExample>
         </ComponentDescription>
@@ -49,29 +49,30 @@ const Page = (): JSX.Element => (
         ))}
 
         <ComponentDescription
-          mainTitle={t('exampleError.title')}
-          description={t('exampleError.description')}
+          mainTitle={t('example.error.title')}
+          description={t('example.error.description')}
           exampleFirst
           filterProps={[]}
         >
           <ComponentExample>
             <Textarea
-              labelText={t('exampleError.label')}
+              labelText={t('example.error.label')}
               status="error"
-              hintText={t('exampleError.hintText')}
-              statusText={t('exampleError.statusText')}
+              hintText={t('example.error.hintText')}
+              visualPlaceholder={t('example.error.placeholder')}
+              statusText={t('example.error.statusText')}
             />
           </ComponentExample>
         </ComponentDescription>
 
         <ComponentDescription
-          mainTitle={t('exampleDisabled.title')}
-          description={t('exampleDisabled.description')}
+          mainTitle={t('example.disabled.title')}
+          description={t('example.disabled.description')}
           exampleFirst
           filterProps={[]}
         >
           <ComponentExample>
-            <Textarea labelText={t('exampleDisabled.label')} disabled />
+            <Textarea labelText={t('example.disabled.label')} disabled />
           </ComponentExample>
         </ComponentDescription>
       </Layout>

--- a/src/pages/components/textinput.tsx
+++ b/src/pages/components/textinput.tsx
@@ -30,49 +30,46 @@ const Page = (): JSX.Element => (
           <ComponentExample
             style={{ marginBottom: suomifiDesignTokens.spacing.s }}
           >
-            <TextInput labelText={t('example.regular.label')} />
+            <TextInput labelText={t('exampleRegular.label')} />
           </ComponentExample>
         </ComponentDescription>
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
 
         <ComponentDescription
-          mainTitle={t('example.success.title')}
-          description={t('example.success.description')}
+          mainTitle={t('exampleSuccess.title')}
+          description={t('exampleSuccess.description')}
           exampleFirst
           filterProps={[]}
         >
           <ComponentExample>
-            <TextInput
-              labelText={t('example.success.label')}
-              status="success"
-            />
+            <TextInput labelText={t('exampleSuccess.label')} status="success" />
           </ComponentExample>
         </ComponentDescription>
 
         <ComponentDescription
-          mainTitle={t('example.error.title')}
-          description={t('example.error.description')}
+          mainTitle={t('exampleError.title')}
+          description={t('exampleError.description')}
           exampleFirst
           filterProps={[]}
         >
           <ComponentExample>
             <TextInput
-              labelText={t('example.error.label')}
+              labelText={t('exampleError.label')}
               status="error"
-              statusText={t('example.error.statusText')}
+              statusText={t('exampleError.statusText')}
             />
           </ComponentExample>
         </ComponentDescription>
 
         <ComponentDescription
-          mainTitle={t('example.disabled.title')}
-          description={t('example.disabled.description')}
+          mainTitle={t('exampleDisabled.title')}
+          description={t('exampleDisabled.description')}
           exampleFirst
           filterProps={[]}
         >
           <ComponentExample>
-            <TextInput labelText={t('example.disabled.label')} disabled />
+            <TextInput labelText={t('exampleDisabled.label')} disabled />
           </ComponentExample>
         </ComponentDescription>
       </Layout>


### PR DESCRIPTION
Textarea and Text Input content keys were accidentally mixed. This PR fixes them. In addition, a placeholder was added to Textarea error example for consistency.