### PR TITLE
[Feature] Text input page update

### DIFF
--- a/locale/af/textinput.json
+++ b/locale/af/textinput.json
@@ -3,6 +3,45 @@
   "intro": "intro",
   "note.title": "note.title",
   "note.items": ["note.item", "note.item", "note.item", "note.item"],
+  "sections": [
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        },
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    },
+    {
+      "title": "section.title",
+      "paragraphs": [
+        {
+          "image.key": "section.paragraph.image.key",
+          "image.alt": "section.paragraph.image.alt",
+          "text": "section.paragraph.text"
+        }
+      ],
+      "links": [
+        {
+          "text": "section.link.text",
+          "url": "section.link.url"
+        }
+      ]
+    }
+  ],
 
   "exampleRegular.label": "exampleRegular.label",
   "exampleSuccess.title": "exampleSuccess.title",
@@ -14,5 +53,9 @@
   "exampleError.statusText": "exampleError.statusText",
   "exampleDisabled.title": "exampleDisabled.title",
   "exampleDisabled.description": "exampleDisabled.description",
-  "exampleDisabled.label": "exampleDisabled.label"
+  "exampleDisabled.label": "exampleDisabled.label",
+  "exampleOptional.title": "exampleOptional.title",
+  "exampleOptional.description": "exampleOptional.description",
+  "exampleOptional.label": "exampleOptional.label",
+  "exampleOptional.optionalText": "exampleOptional.optionalText"
 }

--- a/locale/en/textinput.json
+++ b/locale/en/textinput.json
@@ -3,6 +3,45 @@
   "intro": "",
   "note.title": "",
   "note.items": ["", "", "", ""],
+  "sections": [
+    {
+      "title": "",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
+    {
+      "title": "",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": ""
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    }
+  ],
 
   "exampleRegular.label": "",
   "exampleSuccess.title": "",
@@ -14,5 +53,9 @@
   "exampleError.statusText": "",
   "exampleDisabled.title": "",
   "exampleDisabled.description": "",
-  "exampleDisabled.label": ""
+  "exampleDisabled.label": "",
+  "exampleOptional.title": "",
+  "exampleOptional.description": "",
+  "exampleOptional.label": "",
+  "exampleOptional.optionalText": ""
 }

--- a/locale/fi/textinput.json
+++ b/locale/fi/textinput.json
@@ -15,7 +15,7 @@
         {
           "image.key": "",
           "image.alt": "",
-          "text": "Tekstikenttä koostuu otsakkeesta ja kentästä, jossa on käyttäjää ohjeistava kenttäteksti. Suomi.fi -palvelussa käytetään yleensä puhuttelumuodossa olevaa ohjeistavaa kenttätekstiä. Lisäksi kenttä voi optionaalisesti sisältää ohjetekstin, joka sijoittuu otsakkeen ja kentän väliin, mutta on teknisesti osa otsikkoa. Näin ruudunlukija lukee ohjetekstin otsakkeen jälkeen. Kenttään on liitettävissä notifikaatiotieto mahdollisesta virheestä tai onnistumisesta. Notifikaatiotieto näytetään kentän alapuolella. Tekstimuotoisen notifikaation lisäksi kentän reunus on notifikaation aikana värikoodattu virheen tai onnistumisen merkiksi. Kentälle voidaan asettaa myös ikoni, joka esitetään kentän oikeassa laidassa. Ikonia voidaan hyödyntää kentän käyttötarkoituksen viestimiseen."
+          "text": "Tekstikenttä koostuu otsakkeesta ja kentästä, jossa on käyttäjää ohjeistava kenttäteksti. Suomi.fi -palvelussa käytetään yleensä puhuttelumuodossa olevaa ohjeistavaa kenttätekstiä. Lisäksi kenttä voi sisältää ohjetekstin, joka sijoittuu otsakkeen ja kentän väliin, mutta on teknisesti osa otsikkoa. Näin ruudunlukija lukee ohjetekstin otsakkeen jälkeen. Kenttään on liitettävissä notifikaatiotieto mahdollisesta virheestä tai onnistumisesta. Notifikaatiotieto näytetään kentän alapuolella. Tekstimuotoisen notifikaation lisäksi kentän reunus on notifikaation aikana värikoodattu virheen tai onnistumisen merkiksi. Kentälle voidaan asettaa myös ikoni, joka esitetään kentän oikeassa laidassa. Ikonia voidaan hyödyntää kentän käyttötarkoituksen viestimiseen."
         },
         {
           "image.key": "",

--- a/locale/fi/textinput.json
+++ b/locale/fi/textinput.json
@@ -8,6 +8,45 @@
     "Tekstikentän leveys toimii visuaalisena rajoitteena käyttäjälle ja antaa vihjeen siihen syötettävästä informaation määrästä.",
     "Tekstikenttä komponenttia käytetään silloin kuin käyttäjän tulee täyttää vain yhden rivin informaatiota, kuten esimerkiksi nimensä. Monta riviä (multiline) vaativille vastauksille käytä Tekstialue (Textarea) komponenttia."
   ],
+  "sections": [
+    {
+      "title": "Mistä komponentti koostuu",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Tekstikenttä koostuu otsakkeesta ja kentästä, jossa on käyttäjää ohjeistava kenttäteksti. Suomi.fi -palvelussa käytetään yleensä puhuttelumuodossa olevaa ohjeistavaa kenttätekstiä. Lisäksi kenttä voi optionaalisesti sisältää ohjetekstin, joka sijoittuu otsakkeen ja kentän väliin, mutta on teknisesti osa otsikkoa. Näin ruudunlukija lukee ohjetekstin otsakkeen jälkeen. Kenttään on liitettävissä notifikaatiotieto mahdollisesta virheestä tai onnistumisesta. Notifikaatiotieto näytetään kentän alapuolella. Tekstimuotoisen notifikaation lisäksi kentän reunus on notifikaation aikana värikoodattu virheen tai onnistumisen merkiksi. Kentälle voidaan asettaa myös ikoni, joka esitetään kentän oikeassa laidassa. Ikonia voidaan hyödyntää kentän käyttötarkoituksen viestimiseen."
+        },
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Lähtökohtaisesti kaikki lomakekentät ovat pakollisia, ja valinnaiset kentät merkitään valinnaisuustekstillä (optionalText). Valinnaisuusteksti näytetään suluissa otsakkeen lopussa."
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    },
+    {
+      "title": "Koko ja käyttö",
+      "paragraphs": [
+        {
+          "image.key": "",
+          "image.alt": "",
+          "text": "Tekstikentän leveys on riippuu käyttötilanteesta. Täytettävän asian pitää mahtua tekstikenttään, mutta liian pitkä tekstikenttä antaa väärän viestin käyttäjälle.  Tutkimusten mukaan tyypillisesti kentän pituus on 18-33 merkkiä (englannin kieli). 33 merkkiä on leveydeltään noin 300 px jolloin marginaaleineen 33 merkin tekstikentän sopiva leveys on 320 px. Tekstikenttäkomponentin oletusleveys on 290px. Komponentin koko voi rajoittaa vastauksen laajuutta, mutta se voi myös ohjata käyttäjää vastaamaan riittävän tiiviisti."
+        }
+      ],
+      "links": [
+        {
+          "text": "",
+          "url": ""
+        }
+      ]
+    }
+  ],
 
   "exampleRegular.label": "Normaali tekstikenttä",
   "exampleSuccess.title": "Tekstikenttä hyväksytty (Success Text Input)",
@@ -19,5 +58,9 @@
   "exampleError.statusText": "Virheellinen tieto",
   "exampleDisabled.title": "Tekstikenttä estetty (Disabled Text Input)",
   "exampleDisabled.description": "Disabloitu tekstikenttä estää kentän täyttämisen, kunnes käyttäjä suorittaa toisen vaadittavan toimenpiteen.",
-  "exampleDisabled.label": "Estetty tekstikenttä"
+  "exampleDisabled.label": "Estetty tekstikenttä",
+  "exampleOptional.title": "Valinnainen tekstikenttä ikonilla (Optional Text Input)",
+  "exampleOptional.description": "",
+  "exampleOptional.label": "Tekstikenttä ikonilla",
+  "exampleOptional.optionalText": "valinnainen"
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-syntax-highlighter": "^12.2.1",
     "styled-components": "^5.1.0",
     "suomifi-icons": "1.0.0",
-    "suomifi-ui-components": "^1.1.0"
+    "suomifi-ui-components": "^2.0.0"
   },
   "resolutions": {
     "@wapps/gatsby-plugin-i18next/i18next": "^19.4.0",

--- a/src/pages/components/textinput.tsx
+++ b/src/pages/components/textinput.tsx
@@ -10,8 +10,8 @@ import NoteBox from 'components/NoteBox';
 import { TextInput } from 'components/ExampleComponents';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
+import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
-import NotificationBox from 'components/NotificationBox';
 import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
@@ -20,7 +20,6 @@ const Page = (): JSX.Element => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
         <Heading.h1>{t('title')}</Heading.h1>
-        <NotificationBox />
 
         <Paragraph.lead>
           <Text.lead>{t('intro')}</Text.lead>
@@ -35,6 +34,15 @@ const Page = (): JSX.Element => (
         </ComponentDescription>
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
+
+        {t<SectionProps[]>('sections').map((section, index) => (
+          <Section
+            key={index}
+            mainTitle={section.title}
+            paragraphs={section.paragraphs}
+            links={section.links}
+          />
+        ))}
 
         <ComponentDescription
           mainTitle={t('exampleSuccess.title')}
@@ -70,6 +78,20 @@ const Page = (): JSX.Element => (
         >
           <ComponentExample>
             <TextInput labelText={t('exampleDisabled.label')} disabled />
+          </ComponentExample>
+        </ComponentDescription>
+        <ComponentDescription
+          mainTitle={t('exampleOptional.title')}
+          description={t('exampleOptional.description')}
+          exampleFirst
+          filterProps={[]}
+        >
+          <ComponentExample>
+            <TextInput
+              labelText={t('exampleOptional.label')}
+              icon="mapLocation"
+              optionalText={t('exampleOptional.optionalText')}
+            />
           </ComponentExample>
         </ComponentDescription>
       </Layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,6 +1583,11 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@popperjs/core@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
+  integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
+
 "@reach/alert@0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.10.3.tgz#9e4278edf8e6cfbe94df9a105faaa1c049a84517"
@@ -13278,6 +13283,11 @@ react-fast-compare@^2.0.1, react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-focus-lock@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.4.1.tgz#e842cc93da736b5c5d331799012544295cbcee4f"
@@ -13347,6 +13357,14 @@ react-motion@^0.5.2:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
+
+react-popper@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-reconciler@^0.24.0:
   version "0.24.0"
@@ -15524,17 +15542,19 @@ suomifi-icons@^1.0.0:
   resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-1.0.2.tgz#ba4c078111d16fce12a2562b23b4643ab6543199"
   integrity sha512-Py4ONldrjukDHtW7XsC7egFhSE51dvGpbmWCvGOzKZDJYJickemUhh/89WrBnq/Ms/KZ2oW4vFi52//cqXbsYA==
 
-suomifi-ui-components@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/suomifi-ui-components/-/suomifi-ui-components-1.1.0.tgz#6a8f8f5b3a9d9bb925983c7d9ca746ded91ede6d"
-  integrity sha512-RXYCXr67uRDb3Wx84HgiuNb3pfkaY/aLxl92wD4X6xI1Q8P4Xt97GfJm9aCaadopvOxKbuG5cRODZ+fHw04Ntw==
+suomifi-ui-components@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/suomifi-ui-components/-/suomifi-ui-components-2.0.0.tgz#9590d508c3d3d6983ae52448364a59e8bc58dbed"
+  integrity sha512-AkWdvKk30qZXMcGFW5Bemwsey5G2lH3uYb/Aw8Fw1bxgSDT6DqCmtYZkbRHwXG8JbTPRsUGs6tbW/gcU5a2EXA==
   dependencies:
+    "@popperjs/core" "2.4.4"
     "@reach/listbox" "0.10.4"
     "@reach/menu-button" "0.10.4"
     "@reach/popover" "0.10.4"
     classnames "2.2.6"
     normalize.cssinjs "1.1.1"
     polished "3.5.1"
+    react-popper "2.2.3"
     react-svg "11.0.16"
     suomifi-design-tokens "^2.0.0"
     suomifi-icons "^1.0.0"
@@ -16692,7 +16712,7 @@ void-elements@^2.0.1:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-warning@^4.0.3:
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15542,7 +15542,7 @@ suomifi-icons@^1.0.0:
   resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-1.0.2.tgz#ba4c078111d16fce12a2562b23b4643ab6543199"
   integrity sha512-Py4ONldrjukDHtW7XsC7egFhSE51dvGpbmWCvGOzKZDJYJickemUhh/89WrBnq/Ms/KZ2oW4vFi52//cqXbsYA==
 
-suomifi-ui-components@2.0.0:
+suomifi-ui-components@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/suomifi-ui-components/-/suomifi-ui-components-2.0.0.tgz#9590d508c3d3d6983ae52448364a59e8bc58dbed"
   integrity sha512-AkWdvKk30qZXMcGFW5Bemwsey5G2lH3uYb/Aw8Fw1bxgSDT6DqCmtYZkbRHwXG8JbTPRsUGs6tbW/gcU5a2EXA==


### PR DESCRIPTION
This PR adjusts the text input component page to reflect the recent changes in the component. Removed the WIP notification and added some content and a new example.

Content approved by designers and matched with that in confluence. Not pushed to transifex yet.