### PR TITLE
[Release] 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "suomifi-design-system",
   "private": true,
   "description": "Suomi.fi Design System",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "Jari Porola <jari.porola@gmail.com>",
   "dependencies": {
     "@csstools/normalize.css": "^10.1.0",


### PR DESCRIPTION
## Description
Increase version to 1.0.0 as the design system is no longer considered to be in beta.

As discussed elsewhere, this repository is not published to NPM and there are no external stakeholders who would be interested in the version. Because of that, versioning should reflect internal changes and major version should communicate a larger rework of either content or code.