### PR TITLE
Refactor Example components abstraction to reduce duplication.

### DIFF
--- a/src/components/ExampleComponentUtil.tsx
+++ b/src/components/ExampleComponentUtil.tsx
@@ -1,5 +1,7 @@
 import React, { ComponentClass } from 'react';
 
+type SourceOrDestinationComp = ComponentClass | Function;
+
 const getComponentWithDisplayName = (
   Comp: Function,
   displayName: string,
@@ -10,7 +12,7 @@ const getComponentWithDisplayName = (
 };
 
 const getVariants = (
-  Comp: ComponentClass,
+  Comp: SourceOrDestinationComp,
   displayName: string,
 ): Record<string, Function> =>
   Object.keys(Comp)
@@ -20,8 +22,8 @@ const getVariants = (
     .reduce((obj, item) => ({ ...obj, ...item }), {});
 
 export const addDisplayNames = (
-  DestComp: ComponentClass,
-  SourceComp: ComponentClass,
+  DestComp: SourceOrDestinationComp,
+  SourceComp: SourceOrDestinationComp,
   displayName: string,
 ): void => {
   Object.assign(DestComp, {

--- a/src/components/ExampleComponents.tsx
+++ b/src/components/ExampleComponents.tsx
@@ -1,39 +1,236 @@
+import React, { Component } from 'react';
 import {
-  Breadcrumb as OrigBreadcrumb,
-  Link as OrigLink,
-  Text as OrigText,
-  SearchInput as OrigSearchInput,
-  Icon as OrigIcon,
-  StaticIcon as OrigStaticIcon,
   Block as OrigBlock,
+  Button as OrigButton,
+  ButtonProps,
+  Breadcrumb as OrigBreadcrumb,
+  Checkbox as OrigCheckbox,
+  CheckboxProps,
+  Dropdown as OrigDropdown,
+  DropdownProps,
+  DropdownItem as OrigDropdownItem,
+  DropdownItemProps,
+  ExpanderGroup as OrigExpanderGroup,
+  ExpanderGroupProps,
+  Expander as OrigExpander,
+  ExpanderProps,
+  ExpanderTitle as OrigExpanderTitle,
+  ExpanderTitleProps,
+  ExpanderTitleButton as OrigExpanderTitleButton,
+  ExpanderTitleButtonProps,
+  ExpanderContent as OrigExpanderContent,
+  ExpanderContentProps,
+  Heading as OrigHeading,
+  HeadingProps,
+  Icon as OrigIcon,
   LanguageMenu as OrigLanguageMenu,
   LanguageMenuItem as OrigLanguageMenuItem,
+  Link as OrigLink,
+  Modal as OrigModal,
+  ModalProps,
+  ModalTitle as OrigModalTitle,
+  ModalTitleProps,
+  ModalContent as OrigModalContent,
+  ModalContentProps,
+  ModalFooter as OrigModalFooter,
+  ModalFooterProps,
+  MultiSelect as OrigMultiSelect,
+  MultiSelectProps,
+  MultiSelectData,
+  Paragraph as OrigParagraph,
+  RadioButton as OrigRadioButton,
+  RadioButtonProps,
+  RadioButtonGroup as OrigRadioButtonGroup,
+  RadioButtonGroupProps,
+  SearchInput as OrigSearchInput,
+  StaticIcon as OrigStaticIcon,
+  Text as OrigText,
+  Textarea as OrigTextarea,
+  TextareaProps,
+  TextInput as OrigTextInput,
+  TextInputProps,
+  ToggleButton as OrigToggleButton,
+  ToggleButtonProps,
+  ToggleInput as OrigToggleInput,
+  ToggleInputProps,
+  VisuallyHidden as OrigVisuallyHidden,
 } from 'suomifi-ui-components';
 import { addDisplayNames } from 'components/ExampleComponentUtil';
+
+export class Block extends OrigBlock {}
+addDisplayNames(Block, OrigBlock, 'Block');
 
 export class Breadcrumb extends OrigBreadcrumb {}
 addDisplayNames(Breadcrumb, OrigBreadcrumb, 'Breadcrumb');
 
-export class Link extends OrigLink {}
-addDisplayNames(Link, OrigLink, 'Link');
+export class Button extends Component<ButtonProps> {
+  render(): JSX.Element {
+    return <OrigButton {...this.props} />;
+  }
+}
+addDisplayNames(Button, OrigButton, 'Button');
 
-export class Text extends OrigText {}
-addDisplayNames(Text, OrigText, 'Text');
+export class Checkbox extends Component<CheckboxProps> {
+  render(): JSX.Element {
+    return <OrigCheckbox {...this.props} />;
+  }
+}
+addDisplayNames(Checkbox, OrigCheckbox, 'Checkbox');
 
-export class SearchInput extends OrigSearchInput {}
-addDisplayNames(SearchInput, OrigSearchInput, 'SearchInput');
+export class Dropdown extends Component<DropdownProps> {
+  render(): JSX.Element {
+    return <OrigDropdown {...this.props} />;
+  }
+}
+addDisplayNames(Dropdown, OrigDropdown, 'Dropdown');
+
+export class DropdownItem extends Component<DropdownItemProps> {
+  render(): JSX.Element {
+    return <OrigDropdownItem {...this.props} />;
+  }
+}
+addDisplayNames(DropdownItem, OrigDropdownItem, 'DropdownItem');
+
+export class Expander extends Component<ExpanderProps> {
+  render(): JSX.Element {
+    return <OrigExpander {...this.props} />;
+  }
+}
+addDisplayNames(Expander, OrigExpander, 'Expander');
+
+export class ExpanderGroup extends Component<ExpanderGroupProps> {
+  render(): JSX.Element {
+    return <OrigExpanderGroup {...this.props} />;
+  }
+}
+addDisplayNames(ExpanderGroup, OrigExpanderGroup, 'ExpanderGroup');
+
+export class ExpanderContent extends Component<ExpanderContentProps> {
+  render(): JSX.Element {
+    return <OrigExpanderContent {...this.props} />;
+  }
+}
+addDisplayNames(ExpanderContent, OrigExpanderGroup, 'ExpanderContent');
+
+export class ExpanderTitle extends Component<ExpanderTitleProps> {
+  render(): JSX.Element {
+    return <OrigExpanderTitle {...this.props} />;
+  }
+}
+addDisplayNames(ExpanderTitle, OrigExpanderTitle, 'ExpanderTitle');
+
+export class ExpanderTitleButton extends Component<ExpanderTitleButtonProps> {
+  render(): JSX.Element {
+    return <OrigExpanderTitleButton {...this.props} />;
+  }
+}
+addDisplayNames(
+  ExpanderTitleButton,
+  OrigExpanderTitleButton,
+  'ExpanderTitleButton',
+);
+
+export class Heading extends Component<HeadingProps> {
+  render(): JSX.Element {
+    return <OrigHeading {...this.props} />;
+  }
+}
+addDisplayNames(Heading, OrigHeading, 'Heading');
 
 export class Icon extends OrigIcon {}
 addDisplayNames(Icon, OrigIcon, 'Icon');
-
-export class StaticIcon extends OrigStaticIcon {}
-addDisplayNames(StaticIcon, OrigStaticIcon, 'StaticIcon');
-
-export class Block extends OrigBlock {}
-addDisplayNames(Block, OrigBlock, 'Block');
 
 export class LanguageMenu extends OrigLanguageMenu {}
 addDisplayNames(LanguageMenu, OrigLanguageMenu, 'LanguageMenu');
 
 export class LanguageMenuItem extends OrigLanguageMenuItem {}
 addDisplayNames(LanguageMenuItem, OrigLanguageMenuItem, 'LanguageMenuItem');
+
+export class Link extends OrigLink {}
+addDisplayNames(Link, OrigLink, 'Link');
+
+export class Modal extends Component<ModalProps> {
+  render(): JSX.Element {
+    return <OrigModal {...this.props} />;
+  }
+}
+addDisplayNames(Modal, OrigModal, 'Modal');
+
+export class ModalContent extends Component<ModalContentProps> {
+  render(): JSX.Element {
+    return <OrigModalContent {...this.props} />;
+  }
+}
+addDisplayNames(ModalContent, OrigModalContent, 'ModalContent');
+
+export class ModalTitle extends Component<ModalTitleProps> {
+  render(): JSX.Element {
+    return <OrigModalTitle {...this.props} />;
+  }
+}
+addDisplayNames(ModalTitle, OrigModalTitle, 'ModalTitle');
+
+export class ModalFooter extends Component<ModalFooterProps> {
+  render(): JSX.Element {
+    return <OrigModalFooter {...this.props} />;
+  }
+}
+addDisplayNames(ModalFooter, OrigModalFooter, 'ModalFooter');
+
+export const MultiSelect = function <T extends MultiSelectData>(
+  props: MultiSelectProps<T>,
+): JSX.Element {
+  return <OrigMultiSelect {...props} />;
+};
+addDisplayNames(MultiSelect, OrigMultiSelect, 'MultiSelect');
+
+export class Paragraph extends OrigParagraph {}
+addDisplayNames(Paragraph, OrigParagraph, 'Paragraph');
+
+export const RadioButton = (props: RadioButtonProps): JSX.Element => (
+  <OrigRadioButton {...props} />
+);
+addDisplayNames(RadioButton, OrigRadioButton, 'RadioButton');
+
+export const RadioButtonGroup = (props: RadioButtonGroupProps): JSX.Element => (
+  <OrigRadioButtonGroup {...props} />
+);
+addDisplayNames(RadioButtonGroup, OrigRadioButtonGroup, 'RadioButtonGroup');
+
+export class SearchInput extends OrigSearchInput {}
+addDisplayNames(SearchInput, OrigSearchInput, 'SearchInput');
+
+export class StaticIcon extends OrigStaticIcon {}
+addDisplayNames(StaticIcon, OrigStaticIcon, 'StaticIcon');
+
+export class Text extends OrigText {}
+addDisplayNames(Text, OrigText, 'Text');
+
+export const Textarea = (props: TextareaProps): JSX.Element => (
+  <OrigTextarea {...props} />
+);
+addDisplayNames(Textarea, OrigTextarea, 'Textarea');
+
+export const TextInput = (props: TextInputProps): JSX.Element => (
+  <OrigTextInput {...props} />
+);
+addDisplayNames(TextInput, OrigTextInput, 'TextInput');
+
+export const ToggleButton = (props: ToggleButtonProps): JSX.Element => (
+  <OrigToggleButton {...props} />
+);
+addDisplayNames(ToggleButton, OrigToggleButton, 'ToggleButton');
+
+export const ToggleInput = (props: ToggleInputProps): JSX.Element => (
+  <OrigToggleInput {...props} />
+);
+
+addDisplayNames(ToggleInput, OrigToggleInput, 'ToggleInput');
+
+export class VisuallyHidden extends Component<any> {
+  displayName: 'Button';
+  render(): JSX.Element {
+    return <OrigVisuallyHidden {...this.props} />;
+  }
+}
+addDisplayNames(VisuallyHidden, OrigVisuallyHidden, 'VisuallyHidden');

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import { Button, suomifiDesignTokens } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -13,6 +13,7 @@ import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import MobileDevice from 'components/MobileDevice';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
+import { Button } from 'components/ExampleComponents';
 
 const ExampleWrapper = ({
   children,

--- a/src/pages/components/button.tsx
+++ b/src/pages/components/button.tsx
@@ -14,8 +14,6 @@ import ComponentExample from 'components/ComponentExample';
 import MobileDevice from 'components/MobileDevice';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 
-Button.displayName = 'Button';
-
 const ExampleWrapper = ({
   children,
 }: {

--- a/src/pages/components/checkbox.tsx
+++ b/src/pages/components/checkbox.tsx
@@ -8,12 +8,11 @@ import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
+import { Checkbox } from 'components/ExampleComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
 import Section, { Props as SectionProps } from 'components/Section';
-import { Checkbox, suomifiDesignTokens } from 'suomifi-ui-components';
-
-Checkbox.displayName = 'Checkbox';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
   <Translation ns={['checkbox']}>

--- a/src/pages/components/dropdown.tsx
+++ b/src/pages/components/dropdown.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import {
-  Dropdown,
-  DropdownItem as OrigDropdownItem,
-  DropdownItemProps,
-} from 'suomifi-ui-components';
-
 import Layout from 'components/layout';
 import SEO from 'components/seo';
 import ComponentDescription from 'components/ComponentDescription';
@@ -17,13 +11,7 @@ import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import NotificationBox from 'components/NotificationBox';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-
-Dropdown.displayName = 'Dropdown';
-const DropdownItem = (props: DropdownItemProps): JSX.Element => {
-  return <OrigDropdownItem {...props} />;
-};
-
-DropdownItem.displayName = 'DropdownItem';
+import { Dropdown, DropdownItem } from 'components/ExampleComponents';
 
 const Page = (): JSX.Element => (
   <Translation ns={['dropdown']}>

--- a/src/pages/components/expander.tsx
+++ b/src/pages/components/expander.tsx
@@ -2,17 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import {
-  Expander as OrigExpander,
-  ExpanderProps,
-  ExpanderGroup as OrigExpanderGroup,
-  ExpanderGroupProps,
-  ExpanderTitleButton as OrigExpanderTitleButton,
-  ExpanderTitleButtonProps,
-  ExpanderContent as OrigExpanderContent,
-  ExpanderContentProps,
-  suomifiDesignTokens,
-} from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -22,23 +12,12 @@ import NoteBox from 'components/NoteBox';
 import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-
-const Expander = (props: ExpanderProps): JSX.Element => (
-  <OrigExpander {...props} />
-);
-Expander.displayName = 'Expander';
-const ExpanderGroup = (props: ExpanderGroupProps): JSX.Element => (
-  <OrigExpanderGroup {...props} />
-);
-ExpanderGroup.displayName = 'ExpanderGroup';
-const ExpanderTitleButton = (props: ExpanderTitleButtonProps): JSX.Element => (
-  <OrigExpanderTitleButton {...props} />
-);
-ExpanderTitleButton.displayName = 'ExpanderTitleButton';
-const ExpanderContent = (props: ExpanderContentProps): JSX.Element => (
-  <OrigExpanderContent {...props} />
-);
-ExpanderContent.displayName = 'ExpanderContent';
+import {
+  Expander,
+  ExpanderGroup,
+  ExpanderTitleButton,
+  ExpanderContent,
+} from 'components/ExampleComponents';
 
 const Page = (): JSX.Element => (
   <Translation ns={['expander']}>

--- a/src/pages/components/heading.tsx
+++ b/src/pages/components/heading.tsx
@@ -8,22 +8,22 @@ import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
 import Section, { Props as SectionProps } from 'components/Section';
-import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
+import {
+  Heading as ResponsiveHeading,
+  Text,
+  Paragraph,
+} from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
-import {
-  Heading as SuomifiHeading,
-  suomifiDesignTokens,
-} from 'suomifi-ui-components';
-
-SuomifiHeading.displayName = 'Heading';
+import { Heading } from 'components/ExampleComponents';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 const Page = (): JSX.Element => (
   <Translation ns={['heading']}>
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
-        <Heading variant="h1">{t('title')}</Heading>
+        <ResponsiveHeading variant="h1">{t('title')}</ResponsiveHeading>
 
         <Paragraph.lead>
           <Text.lead>{t('intro')}</Text.lead>
@@ -49,42 +49,42 @@ const Page = (): JSX.Element => (
               alignItems: 'flex-start',
             }}
           >
-            <SuomifiHeading
+            <Heading
               variant="h1hero"
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading 1 with hero styling
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h1"
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h1
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h2"
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h2
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h3"
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h3
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h4"
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h4
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h5"
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h5
-            </SuomifiHeading>
+            </Heading>
           </ComponentExample>
         </ComponentDescription>
 
@@ -95,48 +95,48 @@ const Page = (): JSX.Element => (
               alignItems: 'flex-start',
             }}
           >
-            <SuomifiHeading
+            <Heading
               variant="h1hero"
               smallScreen
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading 1 hero small screen
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h1"
               smallScreen
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h1 small screen
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h2"
               smallScreen
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h2 small screen
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h3"
               smallScreen
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h3 small screen
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h4"
               smallScreen
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h4 small screen
-            </SuomifiHeading>
-            <SuomifiHeading
+            </Heading>
+            <Heading
               variant="h5"
               smallScreen
               style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
             >
               Heading h5 small screen
-            </SuomifiHeading>
+            </Heading>
           </ComponentExample>
         </ComponentDescription>
       </Layout>

--- a/src/pages/components/modal.tsx
+++ b/src/pages/components/modal.tsx
@@ -2,33 +2,34 @@ import React, { useState } from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-
+import { suomifiDesignTokens, ModalProps } from 'suomifi-ui-components';
 import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
-import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import ComponentDescription from 'components/ComponentDescription';
-import Section, { Props as SectionProps } from 'components/Section';
-import ComponentExample from 'components/ComponentExample';
 import {
-  Modal as OrigModal,
-  ModalProps,
-  ModalContent as OrigModalContent,
-  ModalContentProps,
-  ModalTitle as OrigModalTitle,
-  ModalTitleProps,
-  ModalFooter as OrigModalFooter,
-  ModalFooterProps,
+  Text,
+  Paragraph,
+  Modal,
+  ModalContent,
+  ModalTitle,
+  ModalFooter,
   Button,
   Expander,
   ExpanderGroup,
   ExpanderContent,
   ExpanderTitle,
   Checkbox,
-  suomifiDesignTokens,
   VisuallyHidden,
-} from 'suomifi-ui-components';
+} from 'components/ExampleComponents';
+import {
+  Heading,
+  Text as ResponsiveText,
+  Paragraph as ResponsiveParagraph,
+} from 'components/ResponsiveComponents';
+import ComponentDescription from 'components/ComponentDescription';
+import Section, { Props as SectionProps } from 'components/Section';
+import ComponentExample from 'components/ComponentExample';
 
 const Page = (): JSX.Element => (
   <Translation ns={['modal']}>
@@ -37,9 +38,9 @@ const Page = (): JSX.Element => (
         <SEO title={t('title')} />
         <Heading variant="h1">{t('title')}</Heading>
 
-        <Paragraph.lead>
-          <Text.lead>{t('intro')}</Text.lead>
-        </Paragraph.lead>
+        <ResponsiveParagraph.lead>
+          <ResponsiveText.lead>{t('intro')}</ResponsiveText.lead>
+        </ResponsiveParagraph.lead>
 
         <ConfirmExample title="" desc="" noCode />
 
@@ -92,21 +93,7 @@ const ExpanderExampleContent = (): JSX.Element => (
     )}
   </Translation>
 );
-
-const Modal = (props: ModalProps): JSX.Element => <OrigModal {...props} />;
-Modal.displayName = 'Modal';
-const ModalContent = (props: ModalContentProps): JSX.Element => (
-  <OrigModalContent {...props} />
-);
-Modal.displayName = 'Modal';
-const ModalTitle = (props: ModalTitleProps): JSX.Element => (
-  <OrigModalTitle {...props} />
-);
-Modal.displayName = 'Modal';
-const ModalFooter = (props: ModalFooterProps): JSX.Element => (
-  <OrigModalFooter {...props} />
-);
-Modal.displayName = 'Modal';
+ExpanderExampleContent.displayName = 'ExpanderExampleContent';
 
 const DefaultExample = ({
   title,

--- a/src/pages/components/multiselect.tsx
+++ b/src/pages/components/multiselect.tsx
@@ -2,11 +2,6 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import {
-  MultiSelect as OrigMultiSelect,
-  MultiSelectData,
-  MultiSelectProps,
-} from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -17,13 +12,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
 import NotificationBox from 'components/NotificationBox';
-
-const MultiSelect = function <T extends MultiSelectData>(
-  props: MultiSelectProps<T>,
-): JSX.Element {
-  return <OrigMultiSelect {...props} />;
-};
-MultiSelect.displayName = 'MultiSelect';
+import { MultiSelect } from 'components/ExampleComponents';
 
 const Page: React.FC = (): React.ReactElement => {
   return (

--- a/src/pages/components/radiobutton.tsx
+++ b/src/pages/components/radiobutton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -11,18 +12,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
 import Section, { Props as SectionProps } from 'components/Section';
-import {
-  RadioButton,
-  RadioButtonGroup as OrigRadioButtonGroup,
-  RadioButtonGroupProps,
-  suomifiDesignTokens,
-} from 'suomifi-ui-components';
-
-RadioButton.displayName = 'RadioButton';
-const RadioButtonGroup = (props: RadioButtonGroupProps): JSX.Element => (
-  <OrigRadioButtonGroup {...props} />
-);
-RadioButtonGroup.displayName = 'RadioButtonGroup';
+import { RadioButton, RadioButtonGroup } from 'components/ExampleComponents';
 
 const Page = (): JSX.Element => (
   <Translation ns={['radiobutton']}>

--- a/src/pages/components/textarea.tsx
+++ b/src/pages/components/textarea.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -11,9 +12,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
-import { Textarea, suomifiDesignTokens } from 'suomifi-ui-components';
-
-Textarea.displayName = 'Textarea';
+import { Textarea } from 'components/ExampleComponents';
 
 const Page = (): JSX.Element => (
   <Translation ns={['textarea']}>

--- a/src/pages/components/textinput.tsx
+++ b/src/pages/components/textinput.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -11,9 +12,7 @@ import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
-import { TextInput, suomifiDesignTokens } from 'suomifi-ui-components';
-
-TextInput.displayName = 'TextInput';
+import { TextInput } from 'components/ExampleComponents';
 
 const Page = (): JSX.Element => (
   <Translation ns={['textinput']}>

--- a/src/pages/components/toggle.tsx
+++ b/src/pages/components/toggle.tsx
@@ -2,11 +2,7 @@ import React, { useState } from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import {
-  ToggleButton,
-  ToggleInput,
-  suomifiDesignTokens,
-} from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
@@ -16,9 +12,7 @@ import NoteBox from 'components/NoteBox';
 import Section, { Props as SectionProps } from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
 import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-
-ToggleButton.displayName = 'ToggleButton';
-ToggleInput.displayName = 'ToggleInput';
+import { ToggleButton, ToggleInput } from 'components/ExampleComponents';
 
 const Page: React.FC = (): React.ReactElement => {
   const [isButtonChecked, setButtonChecked] = useState(false);

--- a/src/pages/styles/typography.tsx
+++ b/src/pages/styles/typography.tsx
@@ -2,22 +2,21 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { Translation } from 'react-i18next';
 import { withI18next } from '@wapps/gatsby-plugin-i18next';
-import {
-  Heading as SuomifiHeading,
-  suomifiDesignTokens,
-} from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-ui-components';
 
 import Layout from 'components/layout';
 import SEO from 'components/seo';
 import sideNavData from 'config/sidenav/styles';
 import NoteBox from 'components/NoteBox';
 import Section, { Props as SectionProps } from 'components/Section';
-import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
+import {
+  Heading as ResponsiveHeading,
+  Text as ResponsiveText,
+  Paragraph,
+} from 'components/ResponsiveComponents';
 import ComponentDescription from 'components/ComponentDescription';
 import ComponentExample from 'components/ComponentExample';
-import { Text as SuomifiText } from 'components/ExampleComponents';
-
-SuomifiHeading.displayName = 'Heading';
+import { Text, Heading } from 'components/ExampleComponents';
 
 interface ExampleBlockProps {
   title: string;
@@ -51,10 +50,10 @@ const Page = (): JSX.Element => (
     {(t) => (
       <Layout sideNavData={sideNavData(t)}>
         <SEO title={t('title')} />
-        <Heading variant="h1">{t('title')}</Heading>
+        <ResponsiveHeading variant="h1">{t('title')}</ResponsiveHeading>
 
         <Paragraph.lead>
-          <Text.lead>{t('intro')}</Text.lead>
+          <ResponsiveText.lead>{t('intro')}</ResponsiveText.lead>
         </Paragraph.lead>
 
         <NoteBox title={t('note.title')} items={t('note.items')} />
@@ -71,20 +70,20 @@ const Page = (): JSX.Element => (
           title={t('heading.title')}
           description={t('heading.description')}
         >
-          <SuomifiHeading
+          <Heading
             variant="h1hero"
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
             {`Headline h1 hero, line height: ${suomifiDesignTokens.values.typography.heading1Hero.lineHeight.value}${suomifiDesignTokens.values.typography.heading1Hero.lineHeight.unit}`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h1hero"
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
             {`Headline h1 hero small, line height: ${suomifiDesignTokens.values.typography.heading1HeroSmallScreen.lineHeight.value}${suomifiDesignTokens.values.typography.heading1HeroSmallScreen.lineHeight.unit}`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h1"
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -94,15 +93,15 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.heading1.lineHeight.unit ||
               ''
             }`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h1"
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
             {`Headline h1 small, line height: ${suomifiDesignTokens.values.typography.heading1SmallScreen.lineHeight.value}${suomifiDesignTokens.values.typography.heading1SmallScreen.lineHeight.unit}`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h2"
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -112,15 +111,15 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.heading2.lineHeight.unit ||
               ''
             }`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h2"
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
             {`Headline h2 small, line height: ${suomifiDesignTokens.values.typography.heading2SmallScreen.lineHeight.value}${suomifiDesignTokens.values.typography.heading2SmallScreen.lineHeight.unit}`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h3"
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -130,15 +129,15 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.heading3.lineHeight.unit ||
               ''
             }`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h3"
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
             {`Headline h3 small, line height: ${suomifiDesignTokens.values.typography.heading3SmallScreen.lineHeight.value}${suomifiDesignTokens.values.typography.heading3SmallScreen.lineHeight.unit}`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h4"
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -148,15 +147,15 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.heading4.lineHeight.unit ||
               ''
             }`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h4"
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
             {`Headline h4 small, line height: ${suomifiDesignTokens.values.typography.heading4SmallScreen.lineHeight.value}${suomifiDesignTokens.values.typography.heading4SmallScreen.lineHeight.unit}`}
-          </SuomifiHeading>
-          <SuomifiHeading
+          </Heading>
+          <Heading
             variant="h5"
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -166,24 +165,22 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.heading5.lineHeight.unit ||
               ''
             }`}
-          </SuomifiHeading>
+          </Heading>
         </ExampleBlock>
 
         <ExampleBlock
           title={t('textstyles.title')}
           description={t('textstyles.description')}
         >
-          <SuomifiText.lead
-            style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
-          >
+          <Text.lead style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}>
             {`Lead text, line height: ${
               suomifiDesignTokens.values.typography.leadText.lineHeight.value
             }${
               suomifiDesignTokens.values.typography.leadText.lineHeight.unit ||
               ''
             }`}
-          </SuomifiText.lead>
-          <SuomifiText.lead
+          </Text.lead>
+          <Text.lead
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -194,18 +191,16 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.leadTextSmallScreen
                 .lineHeight.unit || ''
             }`}
-          </SuomifiText.lead>
-          <SuomifiText
-            style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
-          >
+          </Text.lead>
+          <Text style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}>
             {`Body text, line height: ${
               suomifiDesignTokens.values.typography.bodyText.lineHeight.value
             }${
               suomifiDesignTokens.values.typography.bodyText.lineHeight.unit ||
               ''
             }`}
-          </SuomifiText>
-          <SuomifiText
+          </Text>
+          <Text
             smallScreen
             style={{ margin: `${suomifiDesignTokens.spacing.xs} 0` }}
           >
@@ -216,7 +211,7 @@ const Page = (): JSX.Element => (
               suomifiDesignTokens.values.typography.bodyTextSmall.lineHeight
                 .unit || ''
             }`}
-          </SuomifiText>
+          </Text>
         </ExampleBlock>
       </Layout>
     )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,9 +3977,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125:
-  version "1.0.30001131"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz#afad8a28fc2b7a0d3ae9407e71085a0ead905d54"
-  integrity sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==
+  version "1.0.30001237"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz"
+  integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description
Refactor example components abstraction to remove redundant code from component code examples. This change reintroduces the example components abstraction for all components to apply displayName. This is needed to allow using components across the site for code example without duplicating displayName logic.

Some issues with Modal code examples are also fixed with this PR.

Additionally, caniuse-lite is upgraded.