### PR TITLE
Fix links in README; remove language from url-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Suomi.fi Design System
 
-Documentation website for the [Suomi.fi Design System](https://vrk-kpa.github.io/suomifi-design-system/fi/)
+Documentation website for the [Suomi.fi Design System](https://vrk-kpa.github.io/suomifi-design-system/)
 
 Built using [suomifi-ui-components](https://github.com/vrk-kpa/suomifi-ui-components)
 
-You can see the current development build at (https://vrk-kpa.github.io/suomifi-design-system/fi/)
+You can see the current development build at (https://vrk-kpa.github.io/suomifi-design-system/)
 
-The site presents the elements, features and possibilities of the [Suomi.fi Design System](https://vrk-kpa.github.io/suomifi-design-system/fi/).
+The site presents the elements, features and possibilities of the [Suomi.fi Design System](https://vrk-kpa.github.io/suomifi-design-system/).
 
 Contents of the site:
 


### PR DESCRIPTION
## Description
Fix the links in the README.
No longer having the language in url-path as we are not using i18n solution anymore.