### PR TITLE
[Fix] InlineAlert usage instructions for Alert component page

### DIFF
--- a/locale/af/alert.json
+++ b/locale/af/alert.json
@@ -2,7 +2,7 @@
   "title": "title",
   "intro": "intro",
   "note.title": "note.title",
-  "note.items": ["note.items", "note.items", "note.items"],
+  "note.items": ["note.item", "note.item", "note.item", "note.item"],
   "sections": [
     {
       "title": "sections.title",

--- a/locale/en/alert.json
+++ b/locale/en/alert.json
@@ -2,7 +2,7 @@
   "title": "",
   "intro": "",
   "note.title": "",
-  "note.items": ["", "", ""],
+  "note.items": ["", "", "", ""],
   "sections": [
     {
       "title": "",

--- a/locale/fi/alert.json
+++ b/locale/fi/alert.json
@@ -5,7 +5,8 @@
   "note.items": [
     "Käytä komponentista aina asiaankuuluvaa varianttia (Alert tai InlineAlert). Ks. 'Koko ja käyttö'.",
     "Alert komponentti on myös semanttisesti alert, joka tarkoittaa, että sen sisällön muuttuessa komponentin sisältö luetaan välittömästi ruudunlukijakäyttäjille.",
-    "InlineAlert komponentissa ruudunlukijakäyttäytyminen on säädettävissä, mutta sitä ei tule kytkeä kokonaan pois päältä."
+    "Sisältöherätteessä ruudunlukijakäyttäytyminen on säädettävissä, mutta sitä ei tule kytkeä kokonaan pois päältä.",
+    "Mikäli sisältöheräte liittyy selkeästi tiettyyn interaktiiviseen elementtiin sivulla, informoi yhteys myös ruudunlukijakäyttäjille käyttäen esimerkiksi 'aria-describedby' attribuuttia"
   ],
   "sections": [
     {


### PR DESCRIPTION
This PR adds instructions that were discussed in the recent accessibility clinic to the Alert component page. The instructions are related to the accessible use of InlineAlert in cases where the alert is connected to a certain interactive element on the page.