### PR TITLE
[Fix] Tooltip example showed weird tags

### DIFF
--- a/src/pages/components/tooltip.tsx
+++ b/src/pages/components/tooltip.tsx
@@ -8,8 +8,8 @@ import sideNavData from 'config/sidenav/components';
 import NoteBox from 'components/NoteBox';
 import Section from 'components/Section';
 import ComponentExample from 'components/ComponentExample';
-import { Heading, Text, Paragraph } from 'components/ResponsiveComponents';
-import { Tooltip } from 'components/ExampleComponents';
+import { Paragraph } from 'components/ResponsiveComponents';
+import { Tooltip, Heading, Text } from 'components/ExampleComponents';
 
 const Page = (): React.ReactElement => {
   const [anchorElement, setAnchorElement] = useState(null);


### PR DESCRIPTION
## Description
Tooltip example was showing weird tags for the `Heading` and `Text` components used in the example.
Problem was caused because example used the components from wrong place therefore missing the required `displayName`.

## How to reproduce the problem
When running in dev mode, `yarn develop`, the problem does not exist.
You have to run in prod mode, `yarn build` & `yarn start` to see the problem without this fix, in e.g `develop` branch.

Then run in the same way with this branch to see that it should be fixed.

## Screenshot
Before the fix:
![Screenshot 2022-08-30 at 9 32 14](https://user-images.githubusercontent.com/53757053/187367242-1093dc45-61d6-4379-9373-c62c50a04de3.png)
