### PR TITLE
[Fix]: WizardNav: Adjust examples based on accessibility clinic feedback

### DIFF
--- a/locale/fi/wizardnavigation.json
+++ b/locale/fi/wizardnavigation.json
@@ -4,7 +4,7 @@
     "note.title": "Saavutettavuus ja käytettävyys",
     "note.items": [
       "Komponentin otsikon ja navigaatioelementtien tekstisisältöjen tulee olla kuvaavia, ja ne on hyvä pyrkiä pitämään mahdollisimman lyhyinä.",
-      "Ruudunlukijasaavutettavuuden varmistamiseksi tulee huolehtia, että yksittäisille navigaatioelementeille (linkit) asetetaan asianmukaiset aria-attribuutit: aria-current tällä hetkellä aktiiviselle vaiheelle, aria-label kertomaan mikäli vaihe on suoritettu ja aria-disabled mikäli linkki on estetty. Estetyt linkit tulee lisäksi asettaa selaimen sarkainjärjestykseen, jotta ruudunlukijakäyttäjien on mahdollista havainnoida ne.",
+      "Ruudunlukijasaavutettavuuden varmistamiseksi tulee huolehtia, että yksittäisille navigaatioelementeille (linkit) asetetaan asianmukaiset aria-attribuutit: aria-current tällä hetkellä aktiiviselle vaiheelle, aria-label kertomaan mikäli vaihe on suoritettu ja aria-disabled mikäli linkki on estetty. Estettyjen linkkien tulee kuitenkin olla näppäimistökäyttäjien saavutettavissa.",
       "Komponentille tulee antaa ylätason aria-label, joka kertoo ruudunlukijalle vaihenavigaation kontekstin ja tarkoituksen.",
       "Vaihenavigaatiolle on lisäksi hyvä antaa HTML-id, jotta siihen voidaan liikkua suoraan esimerkiksi SkipLink-navigaatioelementeistä.",
       "Linkkejä klikattaessa vaihenavigaatiota käyttävän sovelluksen on huolehdittava ruudunlukijan saavan täsmällisen tiedon siitä, että siirryttiin uuteen näkymään."

--- a/locale/fi/wizardnavigation.json
+++ b/locale/fi/wizardnavigation.json
@@ -4,9 +4,10 @@
     "note.title": "Saavutettavuus ja käytettävyys",
     "note.items": [
       "Komponentin otsikon ja navigaatioelementtien tekstisisältöjen tulee olla kuvaavia, ja ne on hyvä pyrkiä pitämään mahdollisimman lyhyinä.",
-      "Ruudunlukijasaavutettavuuden varmistamiseksi tulee huolehtia, että yksittäisille navigaatioelementeille (linkit) asetetaan asianmukaiset aria-attribuutit: aria-current tällä hetkellä aktiiviselle vaiheelle, aria-label kertomaan mikäli vaihe on suoritettu ja aria-disabled mikäli linkki on estetty.",
+      "Ruudunlukijasaavutettavuuden varmistamiseksi tulee huolehtia, että yksittäisille navigaatioelementeille (linkit) asetetaan asianmukaiset aria-attribuutit: aria-current tällä hetkellä aktiiviselle vaiheelle, aria-label kertomaan mikäli vaihe on suoritettu ja aria-disabled mikäli linkki on estetty. Estetyt linkit tulee lisäksi asettaa selaimen sarkainjärjestykseen, jotta ruudunlukijakäyttäjien on mahdollista havainnoida ne.",
       "Komponentille tulee antaa ylätason aria-label, joka kertoo ruudunlukijalle vaihenavigaation kontekstin ja tarkoituksen.",
-      "Vaihenavigaatiolle on lisäksi hyvä antaa HTML-id, jotta siihen voidaan liikkua suoraan esimerkiksi SkipLink-navigaatioelementeistä."
+      "Vaihenavigaatiolle on lisäksi hyvä antaa HTML-id, jotta siihen voidaan liikkua suoraan esimerkiksi SkipLink-navigaatioelementeistä.",
+      "Linkkejä klikattaessa vaihenavigaatiota käyttävän sovelluksen on huolehdittava ruudunlukijan saavan täsmällisen tiedon siitä, että siirryttiin uuteen näkymään."
     ],
     "sections": [
       {

--- a/src/pages/components/wizardnavigation.tsx
+++ b/src/pages/components/wizardnavigation.tsx
@@ -61,12 +61,12 @@ const Page = (): React.ReactElement => {
                 </RouterLink>
               </WizardNavigationItem>
               <WizardNavigationItem status="coming">
-                <RouterLink aria-disabled role="link">
+                <RouterLink aria-disabled role="link" tabIndex={0}>
                   {wizardnavigationContent['example.navitem4']}
                 </RouterLink>
               </WizardNavigationItem>
               <WizardNavigationItem status="coming">
-                <RouterLink aria-disabled role="link">
+                <RouterLink aria-disabled role="link" tabIndex={0}>
                   {wizardnavigationContent['example.navitem5']}
                 </RouterLink>
               </WizardNavigationItem>
@@ -120,12 +120,12 @@ const Page = (): React.ReactElement => {
                 </RouterLink>
               </WizardNavigationItem>
               <WizardNavigationItem status="coming">
-                <RouterLink aria-disabled role="link">
+                <RouterLink aria-disabled role="link" tabIndex={0}>
                   {wizardnavigationContent['example.navitem4']}
                 </RouterLink>
               </WizardNavigationItem>
               <WizardNavigationItem status="coming">
-                <RouterLink aria-disabled role="link">
+                <RouterLink aria-disabled role="link" tabIndex={0}>
                   {wizardnavigationContent['example.navitem5']}
                 </RouterLink>
               </WizardNavigationItem>


### PR DESCRIPTION
This PR changes `<WizardNavigation>` examples so that the elements which are currently disabled are still in the tab order, so screen reader users can know they exist. 

Also added some texts to reflect the feedback received from the accessibility clinic.