### PR TITLE
[Feature] Remove code examples from component pages

### DIFF
--- a/components/ComponentExample/ComponentExample.tsx
+++ b/components/ComponentExample/ComponentExample.tsx
@@ -16,6 +16,7 @@ interface ComponentExampleProps {
   variant?: ComponentExampleVariant;
   children?: ReactNode;
   codeString?: string;
+  showCode?: boolean;
   style?: CSSProperties;
 }
 
@@ -33,6 +34,7 @@ const ComponentExample: React.FunctionComponent<ComponentExampleProps> = ({
   variant,
   filterPropsInExample,
   codeString,
+  showCode = false,
   style,
 }) => {
   const showcase =
@@ -46,26 +48,28 @@ const ComponentExample: React.FunctionComponent<ComponentExampleProps> = ({
   return (
     <>
       {showcase}
-      <Expander className="mt-l mb-l">
-        <ExpanderTitleButton>Koodiesimerkki (React)</ExpanderTitleButton>
-        <ExpanderContent>
-          {codeString ? (
-            <ComponentCode codeString={codeString} />
-          ) : (
-            getWithoutWrappers(children).map((child, index) => (
-              <ComponentCode
-                key={index}
-                filterProps={filterPropsInExample}
-                style={{
-                  paddingTop: index === 0 && !codeString ? '1rem' : 0,
-                }}
-              >
-                {child}
-              </ComponentCode>
-            ))
-          )}
-        </ExpanderContent>
-      </Expander>
+      {showCode && (
+        <Expander className="mt-l mb-l">
+          <ExpanderTitleButton>Koodiesimerkki (React)</ExpanderTitleButton>
+          <ExpanderContent>
+            {codeString ? (
+              <ComponentCode codeString={codeString} />
+            ) : (
+              getWithoutWrappers(children).map((child, index) => (
+                <ComponentCode
+                  key={index}
+                  filterProps={filterPropsInExample}
+                  style={{
+                    paddingTop: index === 0 ? '1rem' : 0,
+                  }}
+                >
+                  {child}
+                </ComponentCode>
+              ))
+            )}
+          </ExpanderContent>
+        </Expander>
+      )}
     </>
   );
 };

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -286,8 +286,8 @@
   },
   "components_main_page": {
     "ingress": "Suomi.fi Design System tarjoaa kokoelman saavutettavia, uudelleenkäytettäviä ja dokumentoituja käyttöliittymäkomponentteja. Komponentit on toteutettu Suomi.fi-identiteetin mukaisina React-komponentteina.",
-    "text": "Komponenttikirjasto tarjoaa kaikki komponentit samasta npm-moduulista. Kirjaston tekninen ohjeistus ja käyttöönotto löytyy GitHub-dokumentaatiosta.",
-    "link_text": "GitHub",
+    "text": "Komponenttikirjasto tarjoaa kaikki komponentit samasta npm-moduulista. Kirjaston tekninen ohjeistus ja käyttöönotto-ohjeet löytyvät erillisestä teknisestä dokumentaatiosta.",
+    "link_text": "Tekninen dokumentaatio",
     "usage": {
       "title": "Komponenttien käyttö",
       "description": "Kirjastosta voi valita käyttöön haluamiaan komponentteja. Komponentit ovat avointa lähdekoodia.",

--- a/pages/components/index.tsx
+++ b/pages/components/index.tsx
@@ -65,7 +65,7 @@ const ComponentsIndexPage: NextPage = () => {
         </Paragraph>
 
         <ExternalLink
-          href="https://github.com/vrk-kpa/suomifi-ui-components"
+          href="https://vrk-kpa.github.io/suomifi-ui-components/"
           labelNewWindow={t('common.opens_in_a_new_tab')}
         >
           {t('components_main_page.link_text')}
@@ -79,7 +79,7 @@ const ComponentsIndexPage: NextPage = () => {
             {t('components_main_page.usage.description')}
           </Paragraph>
 
-          <ComponentExample codeString={basicExample}>
+          <ComponentExample codeString={basicExample} showCode>
             <Button>Example</Button>
           </ComponentExample>
         </Block>
@@ -93,7 +93,7 @@ const ComponentsIndexPage: NextPage = () => {
             <Text>{t('components_main_page.theme.description')}</Text>
           </Paragraph>
 
-          <ComponentExample codeString={themeExampleJSX}>
+          <ComponentExample codeString={themeExampleJSX} showCode>
             <SuomifiThemeProvider theme={customTheme}>
               <Button>Theme</Button>
             </SuomifiThemeProvider>
@@ -113,8 +113,9 @@ const ComponentsIndexPage: NextPage = () => {
           <ComponentExample
             codeString={advancedExample}
             style={{ gap: defaultSuomifiTheme.spacing.m }}
+            showCode
           >
-            <CustomButton>Styled</CustomButton>
+            <CustomButton>Styled Components</CustomButton>
             <Button className="button--custom">Classname</Button>
           </ComponentExample>
         </Block>

--- a/pages/styles/index.tsx
+++ b/pages/styles/index.tsx
@@ -54,7 +54,7 @@ const StylesIndexPage: NextPage = () => {
           <Paragraph marginBottomSpacing="l">
             {t('styles_main_page.style_usage_paragraph_1')}
           </Paragraph>
-          <ComponentExample codeString={styleExampleFromTokens}>
+          <ComponentExample codeString={styleExampleFromTokens} showCode>
             <div
               style={{
                 margin: suomifiDesignTokens.spacing.xl,
@@ -74,7 +74,7 @@ const StylesIndexPage: NextPage = () => {
               {t('styles_main_page.style_usage_paragraph_2')}
             </Paragraph>
           </Block>
-          <ComponentExample codeString={styleExampleFromUIComps} />
+          <ComponentExample codeString={styleExampleFromUIComps} showCode />
         </Block>
       </SideNavLayout>
     </>

--- a/pages/styles/spacing.tsx
+++ b/pages/styles/spacing.tsx
@@ -40,6 +40,7 @@ const StylesIndexPage: NextPage = () => {
           <ComponentExample
             filterPropsInExample={['style', 'className']}
             style={{ flexDirection: 'column' }}
+            showCode
           >
             <Block
               className="flex justify-center align-center"


### PR DESCRIPTION
PR removes code examples (Expanders) from component pages. Hopefully this directs users more towards Styleguidist. 

Examples are still shown on other pages (like main styles & components pages) because it makes sense there. 

This is done by adding a prop called `showCode` to `<ComponentExample>`. Prop defaults to false