### PR TITLE
[FIx] Run npm install with sudo in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Install gh-pages and set git user
           command: |
-            npm install -g gh-pages@5.0.0
+            sudo npm install -g gh-pages@5.0.0
             git config user.email 'ci@example.com'
             git config user.name 'ci'
       - add_ssh_keys:


### PR DESCRIPTION
PR adds sudo to `npm install` command to CircleCI pipeline so that the command won't run into permission issues